### PR TITLE
Fix admin GUI issues and Limits 1.28 compatibility (#68, #69, #70, #71)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <paper.version>1.21.11-R0.1-SNAPSHOT</paper.version>
         <bentobox.version>3.0.0-SNAPSHOT</bentobox.version>
         <level.version>2.17.0</level.version>
-        <limits.version>1.19.1-SNAPSHOT</limits.version>
+        <limits.version>1.28.0-SNAPSHOT</limits.version>
         <vault.version>1.7</vault.version>
 
         <revision>${build.version}-SNAPSHOT</revision>

--- a/src/main/java/world/bentobox/upgrades/UpgradesAddon.java
+++ b/src/main/java/world/bentobox/upgrades/UpgradesAddon.java
@@ -178,6 +178,7 @@ public class UpgradesAddon extends Addon {
         }
         if (this.upgradesDataManager != null)
             this.upgradesDataManager.reload();
+        this.refreshDatabaseUpgrades();
         this.log("Island upgrade addon reloaded");
     }
 

--- a/src/main/java/world/bentobox/upgrades/dataobjects/UpgradeData.java
+++ b/src/main/java/world/bentobox/upgrades/dataobjects/UpgradeData.java
@@ -72,10 +72,10 @@ public class UpgradeData implements DataObject {
 	
 	/**
 	 * If this upgrade is shown to the user
-	 * Default to false
+	 * Default to true so newly created upgrades are immediately active
 	 */
 	@Expose
-	private boolean active = false;
+	private boolean active = true;
 	
 	// ------------------------------------------------------------
 	// Section: Getters

--- a/src/main/java/world/bentobox/upgrades/dataobjects/rewards/LimitsReward.java
+++ b/src/main/java/world/bentobox/upgrades/dataobjects/rewards/LimitsReward.java
@@ -74,8 +74,8 @@ public class LimitsReward extends Reward {
             case "BLOCK" -> {
                 try {
                     Material mat = Material.valueOf(db.getTarget().toUpperCase());
-                    int oldCount = isb.getBlockLimitsOffset().getOrDefault(mat, 0);
-                    isb.setBlockLimitsOffset(mat, oldCount + amount);
+                    int oldCount = isb.getBlockLimitsOffset().getOrDefault(mat.getKey(), 0);
+                    isb.setBlockLimitsOffset(mat.getKey(), oldCount + amount);
                 } catch (IllegalArgumentException e) {
                     addon.logWarning("LimitsReward: invalid material '" + db.getTarget() + "'");
                 }

--- a/src/main/java/world/bentobox/upgrades/dataobjects/rewards/RangeReward.java
+++ b/src/main/java/world/bentobox/upgrades/dataobjects/rewards/RangeReward.java
@@ -16,7 +16,6 @@ import world.bentobox.upgrades.dataobjects.UpgradeTier;
 import world.bentobox.upgrades.ui.utils.AbPanel;
 
 import java.security.InvalidParameterException;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -119,19 +118,24 @@ public class RangeReward extends Reward {
         private void createInterface() {
             this.fillBorder(Material.BLACK_STAINED_GLASS_PANE);
 
+            // Show the formula status in-line with the formula item (#70 items 7 & 8)
             if (this.saved.isValid()) {
-                this.setItems(VALID, new PanelItemBuilder().name(this.getUser()
-                                .getTranslation("upgrades.ui.buttons.validconf"))
+                this.setItems(VALID, new PanelItemBuilder()
+                        .name(this.getUser().getTranslation("upgrades.rewards.rangeupgrade.formulastatus"))
+                        .description(this.saved.getRangeUpgradeEquation())
                         .icon(Material.GREEN_CONCRETE)
                         .build(), 10);
             } else {
-                this.setItems(INVALID, new PanelItemBuilder().name(this.getUser()
-                                .getTranslation("upgrades.ui.buttons.invalidconf"))
+                this.setItems(INVALID, new PanelItemBuilder()
+                        .name(this.getUser().getTranslation("upgrades.rewards.rangeupgrade.formulaneeded"))
+                        .description(this.getUser().getTranslation("upgrades.rewards.rangeupgrade.formulaneededdesc"))
                         .icon(Material.RED_CONCRETE)
                         .build(), 10);
             }
 
-            this.setItems(RULE, new PanelItemBuilder().name(this.saved.getRangeUpgradeEquation())
+            this.setItems(RULE, new PanelItemBuilder()
+                    .name(this.getUser().getTranslation("upgrades.rewards.rangeupgrade.setformula"))
+                    .description(this.saved.getRangeUpgradeEquation())
                     .icon(Material.PAPER)
                     .clickHandler(this.onSetRule())
                     .build(), 22);
@@ -141,10 +145,24 @@ public class RangeReward extends Reward {
             return (panel, client, click, slot) -> {
                 this.getAddon()
                         .getChatInput()
-                        .askOneInput(this.doSetRule(), input -> true,
+                        .askOneInput(this.doSetRule(),
+                                input -> {
+                                    // Validate that input is a parseable math expression (#70 item 8)
+                                    try {
+                                        Map<String, Double> vars = new TreeMap<>();
+                                        vars.put("[level]", 1.0);
+                                        vars.put("[islandLevel]", 1.0);
+                                        vars.put("[numberPlayer]", 1.0);
+                                        Settings.evaluate(input, vars);
+                                        return true;
+                                    } catch (Exception e) {
+                                        return false;
+                                    }
+                                },
                                 client.getTranslation("upgrades.rewards.rangeupgrade.rulequestion",
-                                        "[actual]", this.saved.getRangeUpgradeEquation()), "", client,
-                                false);
+                                        "[actual]", this.saved.getRangeUpgradeEquation()),
+                                client.getTranslation("upgrades.rewards.rangeupgrade.invalidrule"),
+                                client, false);
                 return true;
             };
         }

--- a/src/main/java/world/bentobox/upgrades/listeners/JoinPermCheckListener.java
+++ b/src/main/java/world/bentobox/upgrades/listeners/JoinPermCheckListener.java
@@ -7,7 +7,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 
-import world.bentobox.limits.Settings.EntityGroup;
+import world.bentobox.limits.EntityGroup;
 import world.bentobox.limits.events.LimitsPermCheckEvent;
 import world.bentobox.upgrades.UpgradesAddon;
 import world.bentobox.upgrades.UpgradesManager;

--- a/src/main/java/world/bentobox/upgrades/listeners/LimitsPermCheckListener.java
+++ b/src/main/java/world/bentobox/upgrades/listeners/LimitsPermCheckListener.java
@@ -7,7 +7,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 
-import world.bentobox.limits.Settings.EntityGroup;
+import world.bentobox.limits.EntityGroup;
 import world.bentobox.limits.events.LimitsPermCheckEvent;
 import world.bentobox.upgrades.UpgradesAddon;
 import world.bentobox.upgrades.UpgradesManager;

--- a/src/main/java/world/bentobox/upgrades/ui/admin/AdminList.java
+++ b/src/main/java/world/bentobox/upgrades/ui/admin/AdminList.java
@@ -65,7 +65,7 @@ public final class AdminList<Item extends PanelAdminItem> extends AbPanel {
 
         if (this.createButton != null && this.createName != null) {
             this.setItems(CREATE, new PanelItemBuilder().name(this.createName)
-                    .icon(Material.GREEN_STAINED_GLASS_PANE)
+                    .icon(Material.EMERALD)
                     .clickHandler(this.onClickCreate)
                     .build(), 4);
         }

--- a/src/main/java/world/bentobox/upgrades/ui/admin/AdminPanel.java
+++ b/src/main/java/world/bentobox/upgrades/ui/admin/AdminPanel.java
@@ -1,6 +1,8 @@
 package world.bentobox.upgrades.ui.admin;
 
+import java.util.List;
 import java.util.function.Consumer;
+import java.util.stream.IntStream;
 
 import org.bukkit.Material;
 import org.bukkit.event.inventory.ClickType;
@@ -13,105 +15,124 @@ import world.bentobox.bentobox.api.user.User;
 import world.bentobox.upgrades.UpgradesAddon;
 import world.bentobox.upgrades.dataobjects.UpgradeData;
 import world.bentobox.upgrades.ui.utils.AbPanel;
-import world.bentobox.upgrades.ui.admin.YesNoPanel;
 
+/**
+ * The admin panel for managing DB-backed upgrades.
+ * Opens directly as a list view — no intermediate screen.
+ * Left-click an upgrade to edit it; right-click to delete it.
+ * An "Add upgrade" button is always visible.
+ */
 public class AdminPanel extends AbPanel {
-	
-	protected static final String ADD = "add";
-	protected static final String EDIT = "edit";
-	protected static final String DELETE = "delete";
+
+	private static final String ADD = "add";
+	private static final String EMPTY = "empty";
 
 	public AdminPanel(UpgradesAddon addon, GameModeAddon gamemode, User user) {
 		this(addon, gamemode, user, null);
 	}
-	
+
 	public AdminPanel(UpgradesAddon addon, GameModeAddon gamemode, User user, AbPanel parent) {
 		super(addon, gamemode, user, user.getTranslation("upgrades.ui.titles.adminupgrade"), parent);
-		
 		this.fillBorder(Material.BLACK_STAINED_GLASS_PANE);
-		
+		// Content is built in onBuildHook, called by getBuild()
+	}
+
+	/**
+	 * Called every time getBuild() is invoked. Clears stale items and rebuilds
+	 * from the current DB state so returning from EditUpgradePanel always shows
+	 * fresh data.
+	 */
+	@Override
+	protected void onBuildHook() {
+		this.clearItems();
+		this.setupNavigationButton();
+		this.createInterface();
+	}
+
+	private void createInterface() {
 		this.setItems(ADD, new PanelItemBuilder()
 				.name(this.getUser().getTranslation("upgrades.ui.buttons.addupgrade"))
 				.icon(Material.ANVIL)
 				.clickHandler(this.onAdd)
-				.build(), 13);
-		this.setItems(EDIT, new PanelItemBuilder()
-				.name(this.getUser().getTranslation("upgrades.ui.buttons.editupgrade"))
-				.icon(Material.WRITABLE_BOOK)
-				.clickHandler(this.onEdit)
-				.build(), 22);
-		this.setItems(DELETE, new PanelItemBuilder()
-				.name(this.getUser().getTranslation("upgrades.ui.buttons.deleteupgrade"))
-				.icon(Material.LAVA_BUCKET)
-				.clickHandler(this.onDelete)
-				.build(), 31);
+				.build(), 4);
+
+		List<UpgradeData> upgrades = this.getAddon().getUpgradeDataManager()
+				.getUpgradeDataByGameMode(this.getGamemode().getDescription().getName());
+
+		if (upgrades.isEmpty()) {
+			this.setItems(EMPTY, new PanelItemBuilder()
+					.name(this.getUser().getTranslation("upgrades.ui.buttons.noupgrades"))
+					.icon(Material.BARRIER)
+					.build(), 22);
+		} else {
+			IntStream.range(0, upgrades.size()).forEach(idx -> {
+				UpgradeData upgrade = upgrades.get(idx);
+				int pos = ((idx / 7) * 9) + (idx % 7) + 10;
+				this.setItems(upgrade.getUniqueId(), new PanelItemBuilder()
+						.name(upgrade.getName())
+						.icon(upgrade.getIcon())
+						.description(
+								this.getUser().getTranslation("upgrades.ui.buttons.leftclickedit"),
+								this.getUser().getTranslation("upgrades.ui.buttons.rightclickdelete"))
+						.clickHandler(this.onClickUpgrade(upgrade))
+						.build(), pos);
+			});
+		}
 	}
-	
-	private ClickHandler onAdd = (Panel panel, User client, ClickType click, int slot) -> {
+
+	private final ClickHandler onAdd = (Panel panel, User client, ClickType click, int slot) -> {
 		this.getAddon().getChatInput().askOneInput(this.addUpgrade,
-			input -> {
-				// Input validation
-				String uniqueId = this.getGamemode().getDescription().getName() + "_" + input;
-				// Invalid if uniqueId already exist
-				return !this.getAddon().getUpgradeDataManager().hasUpgradeData(uniqueId);
-			},
-			client.getTranslation("upgrades.chatinput.admin.question.getupgradeid"), 
-			client.getTranslation("upgrades.chatinput.admin.invalid.getupgradeid"),
-			client, true);
+				input -> {
+					String uniqueId = this.getGamemode().getDescription().getName() + "_" + input;
+					return !this.getAddon().getUpgradeDataManager().hasUpgradeData(uniqueId);
+				},
+				client.getTranslation("upgrades.chatinput.admin.question.getupgradeid"),
+				client.getTranslation("upgrades.chatinput.admin.invalid.getupgradeid"),
+				client, true);
 		return true;
 	};
-	
-	private ClickHandler onEdit = (Panel panel, User client, ClickType click, int slot) -> {
-		new ListUpgradeDataPanel(this.getAddon(),
-				this.getGamemode(), client,
-				client.getTranslation("upgrades.ui.titles.editlist"),
-				this, this.doEdit)
-			.getBuild().build();
-		return true;
-	};
-	
-	private Consumer<UpgradeData> doEdit = (UpgradeData upgrade) -> {
-		new EditUpgradePanel(this.getAddon(), this.getGamemode(), this.getUser(), upgrade, this)
-			.getBuild().build();
-	};
-	
-	private ClickHandler onDelete = (Panel panel, User client, ClickType click, int slot) -> {
-		new ListUpgradeDataPanel(this.getAddon(),
-				this.getGamemode(), client,
-				client.getTranslation("upgrades.ui.titles.deletelist"),
-				this, this.doDelete)
-			.getBuild().build();
-		return true;
-	};
-	
-	private Consumer<UpgradeData> doDelete = (UpgradeData upgrade) -> {
-		new YesNoPanel(this.getAddon(),
-				this.getGamemode(), this.getUser(),
-				this.getUser().getTranslation("upgrades.ui.titles.delete",
-						"[name]", upgrade.getUniqueId()),
-				this, delete -> {
-					if (delete) {
-						this.getAddon().getUpgradeDataManager().deleteUpgradeData(upgrade);
-					}
-					
-					this.getBuild().build();
-				}).getBuild().build();
-	};
-	
-	private Consumer<String> addUpgrade = input -> {
+
+	private final Consumer<String> addUpgrade = input -> {
 		String uniqueId = this.getGamemode().getDescription().getName() + "_" + input;
-		
+
 		UpgradeData newUpgrade = this.getAddon().getUpgradeDataManager()
 				.createUpgradeData(uniqueId, this.getGamemode().getDescription().getName(), this.getUser());
-		
+
 		if (newUpgrade == null) {
 			this.getUser().sendMessage("upgrades.error.unknownerror");
 			this.getAddon().logError("Couldn't create the upgradeData with id " + uniqueId);
 			return;
 		}
-		
+
+		// Use the user-typed name as the display name (#70 item 1)
+		newUpgrade.setName(input);
+		this.getAddon().getUpgradeDataManager().saveUpgradeData(newUpgrade);
+
 		new EditUpgradePanel(this.getAddon(), this.getGamemode(), this.getUser(), newUpgrade, this)
-			.getBuild().build();
+				.getBuild().build();
 	};
-	
+
+	private ClickHandler onClickUpgrade(UpgradeData upgrade) {
+		return (Panel panel, User client, ClickType click, int slot) -> {
+			if (click.isLeftClick()) {
+				new EditUpgradePanel(this.getAddon(), this.getGamemode(), client, upgrade, this)
+						.getBuild().build();
+			} else if (click.isRightClick()) {
+				new YesNoPanel(this.getAddon(),
+						this.getGamemode(), client,
+						client.getTranslation("upgrades.ui.titles.delete",
+								"[name]", upgrade.getName()),
+						this, delete -> {
+							if (delete) {
+								this.getAddon().getUpgradeDataManager().deleteUpgradeData(upgrade);
+								this.getAddon().refreshDatabaseUpgrades();
+							}
+							// getBuild() triggers onBuildHook() which refreshes the list
+							this.getBuild().build();
+						}).getBuild().build();
+			}
+			return true;
+		};
+	}
+
 }

--- a/src/main/java/world/bentobox/upgrades/ui/admin/EditUpgradePanel.java
+++ b/src/main/java/world/bentobox/upgrades/ui/admin/EditUpgradePanel.java
@@ -29,7 +29,7 @@ public class EditUpgradePanel extends AbPanel {
 	private UpgradeData upgrade;
 
 	public EditUpgradePanel(UpgradesAddon addon, GameModeAddon gamemode, User user, UpgradeData upgrade, AbPanel parent) {
-		super(addon, gamemode, user, upgrade.getUniqueId(), parent);
+		super(addon, gamemode, user, upgrade.getName(), parent);
 		this.upgrade = upgrade;
 		
 		this.fillBorder(Material.BLACK_STAINED_GLASS_PANE);
@@ -75,23 +75,30 @@ public class EditUpgradePanel extends AbPanel {
 				.clickHandler(this.onSetIcon)
 				.build(), 30);
 		
+		boolean hasTiers = !this.getAddon().getUpgradeDataManager()
+				.getUpgradeTierByUpgradeData(this.upgrade).isEmpty();
+
 		this.setItems(TIERADD, new PanelItemBuilder()
 				.name(this.getUser().getTranslation("upgrades.ui.editupgradepanel.tieradd"))
+				.description(hasTiers ? "" :
+						this.getUser().getTranslation("upgrades.ui.editupgradepanel.tierrequired"))
 				.icon(Material.ANVIL)
 				.clickHandler(this.onTierAdd)
 				.build(), 14);
-		
-		this.setItems(TIEREDIT, new PanelItemBuilder()
-				.name(this.getUser().getTranslation("upgrades.ui.editupgradepanel.tieredit"))
-				.icon(Material.WRITABLE_BOOK)
-				.clickHandler(this.onTierEdit)
-				.build(), 23);
-		
-		this.setItems(TIERDELETE, new PanelItemBuilder()
-				.name(this.getUser().getTranslation("upgrades.ui.editupgradepanel.tierdelete"))
-				.icon(Material.LAVA_BUCKET)
-				.clickHandler(this.onTierDelete)
-				.build(), 32);
+
+		if (hasTiers) {
+			this.setItems(TIEREDIT, new PanelItemBuilder()
+					.name(this.getUser().getTranslation("upgrades.ui.editupgradepanel.tieredit"))
+					.icon(Material.WRITABLE_BOOK)
+					.clickHandler(this.onTierEdit)
+					.build(), 23);
+
+			this.setItems(TIERDELETE, new PanelItemBuilder()
+					.name(this.getUser().getTranslation("upgrades.ui.editupgradepanel.tierdelete"))
+					.icon(Material.LAVA_BUCKET)
+					.clickHandler(this.onTierDelete)
+					.build(), 32);
+		}
 		
 		this.setItems(ORDER, new PanelItemBuilder()
 				.name(this.getUser().getTranslation("upgrades.ui.editupgradepanel.order",
@@ -104,6 +111,9 @@ public class EditUpgradePanel extends AbPanel {
 	
 	private ClickHandler onActive = (panel, client, click, slot) -> {
 		this.upgrade.setActive(!this.upgrade.isActive());
+		// Persist the change and update the player-facing shop (#71)
+		this.getAddon().getUpgradeDataManager().saveUpgradeData(this.upgrade);
+		this.getAddon().refreshDatabaseUpgrades();
 		this.setButton();
 		this.getBuild().build();
 		return true;
@@ -173,15 +183,19 @@ public class EditUpgradePanel extends AbPanel {
 		String uniqueId = this.getGamemode().getDescription().getName() + "_" + input;
 		List<UpgradeTier> tiers = this.getAddon().getUpgradeDataManager().getUpgradeTierByUpgradeData(this.upgrade);
 		int lastpos = tiers.size() > 0 ? tiers.get(tiers.size() - 1).getEndLevel() + 1 : 0;
-		
+
 		UpgradeTier newTier = this.getAddon().getUpgradeDataManager()
 				.createUpgradeTier(uniqueId, this.upgrade, lastpos, lastpos, this.getUser());
-		
+
 		if (newTier == null) {
 			this.getUser().sendMessage("upgrades.error.unknownerror");
 			this.getAddon().logError("Couldn't create the upgradeTier with id " + uniqueId);
 			return;
 		}
+
+		// Use the user-typed name as display name (#70 item 5)
+		newTier.setName(input);
+		this.getAddon().getUpgradeDataManager().saveUpgradeTier(newTier);
 		
 		new EditTierPanel(this.getAddon(),
 				this.getGamemode(), this.getUser(), newTier,

--- a/src/main/java/world/bentobox/upgrades/ui/admin/ListUpgradeDataPanel.java
+++ b/src/main/java/world/bentobox/upgrades/ui/admin/ListUpgradeDataPanel.java
@@ -39,7 +39,7 @@ public class ListUpgradeDataPanel extends AbPanel {
 				// (idx / 7) = row    (idx % 7) = column
 				int pos = ((idx / 7) * 9) + (idx % 7) + 10;
 				this.setItems(upgrade.getUniqueId(), new PanelItemBuilder()
-						.name(upgrade.getUniqueId())
+						.name(upgrade.getName())
 						.icon(upgrade.getIcon())
 						.clickHandler(this.onClick(upgrade))
 						.build(), pos);

--- a/src/main/java/world/bentobox/upgrades/ui/admin/ListUpgradeTierPanel.java
+++ b/src/main/java/world/bentobox/upgrades/ui/admin/ListUpgradeTierPanel.java
@@ -40,7 +40,7 @@ public class ListUpgradeTierPanel extends AbPanel {
 				UpgradeTier tier = this.tiers.get(idx);
 				int pos = ((idx / 7) * 9) + (idx % 7) + 10;
 				this.setItems(tier.getUniqueId(), new PanelItemBuilder()
-					.name(tier.getUniqueId())
+					.name(tier.getName())
 					.icon(tier.getIcon())
 					.clickHandler(this.onClickEdit(tier))
 					.build(), pos);

--- a/src/main/java/world/bentobox/upgrades/ui/utils/AbPanel.java
+++ b/src/main/java/world/bentobox/upgrades/ui/utils/AbPanel.java
@@ -35,10 +35,18 @@ public class AbPanel {
 		this.user = user;
 		this.title = title;
 		this.parent = parent;
-		
+
 		this.border = new ArrayList<AbPanel.PanelSlot>();
 		this.items = new HashMap<String, AbPanel.PanelSlot>();
-		
+
+		this.setupNavigationButton();
+	}
+
+	/**
+	 * Sets up (or re-sets up) the return or exit button at slot 8.
+	 * Call this after clearItems() to restore the navigation button.
+	 */
+	protected void setupNavigationButton() {
 		if (parent != null) {
 			PanelItem returnItem = new PanelItemBuilder()
 					.name(this.user.getTranslation("upgrades.ui.buttons.return"))
@@ -61,8 +69,23 @@ public class AbPanel {
 			this.setItems(EXIT, exitItem, 8);
 		}
 	}
+
+	/**
+	 * Hook called at the start of getBuild() before building the panel.
+	 * Override in subclasses to refresh panel content dynamically.
+	 */
+	protected void onBuildHook() {}
 	
+	/**
+	 * Clears all named panel items (but not the border).
+	 * Use in onBuildHook() to allow dynamic refresh of panel content.
+	 */
+	protected void clearItems() {
+		this.items.clear();
+	}
+
 	public PanelBuilder getBuild() {
+		this.onBuildHook();
 		PanelBuilder builder = new PanelBuilder();
 		
 		builder.user(this.user);

--- a/src/main/java/world/bentobox/upgrades/upgrades/BlockLimitsUpgrade.java
+++ b/src/main/java/world/bentobox/upgrades/upgrades/BlockLimitsUpgrade.java
@@ -139,9 +139,9 @@ public class BlockLimitsUpgrade extends UpgradeAPI {
         if (!super.doUpgrade(user, island))
             return false;
 
-        int oldCount = isb.getBlockLimitsOffset().getOrDefault(block, 0);
+        int oldCount = isb.getBlockLimitsOffset().getOrDefault(block.getKey(), 0);
         int newCount = oldCount + this.getUpgradeValues(user).getUpgradeValue();
-        isb.setBlockLimitsOffset(block, newCount);
+        isb.setBlockLimitsOffset(block.getKey(), newCount);
 
         user.sendMessage("upgrades.ui.upgradepanel.limitsupgradedone", BLOCK, this.block.toString(), LEVEL,
                 Integer.toString(this.getUpgradeValues(user).getUpgradeValue()));

--- a/src/main/java/world/bentobox/upgrades/upgrades/DatabaseUpgrade.java
+++ b/src/main/java/world/bentobox/upgrades/upgrades/DatabaseUpgrade.java
@@ -110,6 +110,10 @@ public class DatabaseUpgrade extends UpgradeAPI {
     @Override
     public boolean isShowed(User user, Island island) {
         if (!upgradeData.isActive()) return false;
+        // Don't show upgrades with no tiers configured — they'd appear "maxed out"
+        List<UpgradeTier> tiers = this.getUpgradesAddon().getUpgradeDataManager()
+                .getUpgradeTierByUpgradeData(upgradeData);
+        if (tiers.isEmpty()) return false;
         return this.getUpgradesAddon().getPlugin().getIWM().getAddon(island.getWorld())
                 .map(a -> a.getDescription().getName())
                 .orElse("")

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -70,6 +70,7 @@ upgrades:
       tieradd: "Add tier"
       tieredit: "Edit tier"
       tierdelete: "Delete tier"
+      tierrequired: "Add at least one tier before editing or deleting"
       order: "Actual order: [order]"
       orderdesc: |-
         Click to change order
@@ -120,6 +121,9 @@ upgrades:
       active: "Active"
       validconf: "Valid configuration"
       invalidconf: "Invalid configuration"
+      noupgrades: "No upgrades yet — click 'Add upgrade' to create one"
+      leftclickedit: "&aLeft click: Edit"
+      rightclickdelete: "&cRight click: Delete"
     titles:
       adminupgrade: "Admin upgrade"
       delete: "Delete: [name]"
@@ -171,8 +175,13 @@ upgrades:
         Careful to not go over the island limit
       paneltitle: "Range upgrade reward"
       rulequestion: |-
-        Enter the new rule for this range upgrade reward
+        Enter the range formula (e.g. 5, or 2*[level])
         Actual: [actual]
+      invalidrule: "Invalid formula. Use a number or math expression (e.g. 5, 2*[level])"
+      setformula: "Set range formula"
+      formulastatus: "Formula OK"
+      formulaneeded: "Formula needed"
+      formulaneededdesc: "Click the paper icon to set a range formula"
     limits:
       name: "Limits upgrade"
       description: "Increases [type] limit for [target] by [amount]"


### PR DESCRIPTION
## Summary

- Fixes compatibility with Limits 1.28.0 API (NamespacedKey for block operations, updated EntityGroup import)
- Resolves admin GUI bugs and UX improvements from issues #68, #69, #70, #71

## Changes

### Limits 1.28.0 compatibility
- Updated `pom.xml` to Limits `1.28.0-SNAPSHOT`
- `BlockLimitsUpgrade`: block limit offset now uses `NamespacedKey` (`block.getKey()`) instead of `Material`
- `LimitsReward`: same fix for the DB-backed reward
- `JoinPermCheckListener` / `LimitsPermCheckListener`: updated `EntityGroup` import to `world.bentobox.limits.EntityGroup` (moved from inner class)

### #71 — DB upgrades not appearing in player panel
- `EditUpgradePanel`: toggling active now immediately calls `saveUpgradeData()` + `refreshDatabaseUpgrades()`
- `UpgradesAddon.onReload()`: also calls `refreshDatabaseUpgrades()`
- `DatabaseUpgrade.isShowed()`: returns false when no tiers configured (prevents "maxed out" display)

### #69 — Admin panel opens directly in list view
- `AdminPanel` rewritten as a direct list: no intermediate Add/Edit/Delete selector screen
- Left-click to edit, right-click to delete with confirmation
- `AbPanel` gains `onBuildHook()` / `clearItems()` / `setupNavigationButton()` so the list auto-refreshes on every `getBuild()` call

### #68 — Empty admin list on fresh install
- New list shows a descriptive empty-state item guiding admins to add their first upgrade

### #70 — UX improvements
1. User-typed name used as display name (not the `GameMode_input` uniqueId) for upgrades and tiers
2. New upgrades default to `active=true`
4. Tier Edit/Delete buttons hidden when no tiers exist; Add tier shows a hint
5. Tier name shown in list panels instead of uniqueId
6. Add reward/price button changed from green glass pane to Emerald
7. Range reward status icon shows the actual formula value instead of generic "Valid Configuration"
8. Range reward formula input validated as a parseable math expression

## Test plan

- [ ] `mvn test` passes (70 tests)
- [ ] Start server with BSkyBlock + Level + Limits 1.28 + Vault
- [ ] Run `/bsb admin upgrade` → list opens immediately with "No upgrades yet" message
- [ ] Add an upgrade → display name is the typed name, not prefixed ID
- [ ] Add a tier → tier name is the typed name
- [ ] Set upgrade to active → appears immediately in `/is upgrades` without restart
- [ ] Right-click upgrade in admin list → delete confirmation, list refreshes after delete
- [ ] Range reward: enter invalid text → rejected; enter valid formula → accepted
- [ ] Old-style block/entity limit upgrades work without NoSuchMethodError

🤖 Generated with [Claude Code](https://claude.com/claude-code)