### PR TITLE
Add lore text wrapping in admin GUI panels (#73)

### DIFF
--- a/src/main/java/world/bentobox/upgrades/ui/admin/AdminList.java
+++ b/src/main/java/world/bentobox/upgrades/ui/admin/AdminList.java
@@ -82,7 +82,7 @@ public final class AdminList<Item extends PanelAdminItem> extends AbPanel {
                     if (this.rightClickDesc != null)
                         desc.add(this.rightClickDesc);
 
-                    desc.add(item.getAdminDescription(this.getUser()));
+                    desc.addAll(wrapText(item.getAdminDescription(this.getUser()), LORE_MAX_WIDTH));
 
                     this.setItems(item.getName() + "-" + idx,
                             new PanelItemBuilder().name(item.getAdminName(this.getUser()))

--- a/src/main/java/world/bentobox/upgrades/ui/admin/EditTierPanel.java
+++ b/src/main/java/world/bentobox/upgrades/ui/admin/EditTierPanel.java
@@ -62,7 +62,7 @@ public final class EditTierPanel extends AbPanel {
                 new PanelItemBuilder().name(
                                 this.getUser()
                                         .getTranslation("upgrades.ui.edittierpanel.description"))
-                        .description(this.tier.getDescription())
+                        .description(wrapLore(this.tier.getDescription()))
                         .icon(Material.WRITTEN_BOOK)
                         .clickHandler(this.onSetDescription)
                         .build(),

--- a/src/main/java/world/bentobox/upgrades/ui/admin/EditUpgradePanel.java
+++ b/src/main/java/world/bentobox/upgrades/ui/admin/EditUpgradePanel.java
@@ -63,7 +63,7 @@ public class EditUpgradePanel extends AbPanel {
 		
 		this.setItems(DESCRIPTION, new PanelItemBuilder()
 				.name(this.getUser().getTranslation("upgrades.ui.editupgradepanel.description"))
-				.description(this.upgrade.getDescription())
+				.description(wrapLore(this.upgrade.getDescription()))
 				.icon(Material.WRITTEN_BOOK)
 				.clickHandler(this.onSetDescription)
 				.build(), 21);

--- a/src/main/java/world/bentobox/upgrades/ui/utils/AbPanel.java
+++ b/src/main/java/world/bentobox/upgrades/ui/utils/AbPanel.java
@@ -8,6 +8,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.bukkit.Material;
 
@@ -22,7 +23,10 @@ public class AbPanel {
 	
 	protected static final String RETURN = "return";
 	protected static final String EXIT = "exit";
-	
+
+	/** Maximum characters per lore line before word-wrapping. */
+	protected static final int LORE_MAX_WIDTH = 35;
+
 	protected static final Set<Material> BADICON = new HashSet<Material>(Arrays.asList(
 			Material.AIR,
 			Material.CAVE_AIR,
@@ -167,6 +171,46 @@ public class AbPanel {
 		return parent;
 	}
 	
+	/**
+	 * Word-wraps a single string into multiple lines, each no wider than
+	 * {@code maxWidth} characters. Breaks only on spaces.
+	 *
+	 * @param text     the text to wrap (may be null or empty)
+	 * @param maxWidth maximum characters per line
+	 * @return list of wrapped lines
+	 */
+	protected static List<String> wrapText(String text, int maxWidth) {
+		if (text == null || text.isEmpty()) return Collections.emptyList();
+		List<String> lines = new ArrayList<>();
+		StringBuilder current = new StringBuilder();
+		for (String word : text.split(" ")) {
+			if (current.length() == 0) {
+				current.append(word);
+			} else if (current.length() + 1 + word.length() <= maxWidth) {
+				current.append(' ').append(word);
+			} else {
+				lines.add(current.toString());
+				current = new StringBuilder(word);
+			}
+		}
+		if (current.length() > 0) lines.add(current.toString());
+		return lines;
+	}
+
+	/**
+	 * Word-wraps every entry in a lore list at {@link #LORE_MAX_WIDTH} characters,
+	 * returning a flat list of wrapped lines.
+	 *
+	 * @param lore source lore lines (may contain long strings)
+	 * @return wrapped lore ready for {@link PanelItemBuilder#description(List)}
+	 */
+	protected static List<String> wrapLore(List<String> lore) {
+		if (lore == null) return Collections.emptyList();
+		return lore.stream()
+				.flatMap(line -> wrapText(line, LORE_MAX_WIDTH).stream())
+				.collect(Collectors.toList());
+	}
+
 	protected void setItems(String name, PanelItem item, int slot) {
 		this.items.put(name, new PanelSlot(item, slot));
 	}


### PR DESCRIPTION
## Summary

Closes #73.

Adds word-wrapping for lore text in the admin GUI so long descriptions don't produce excessively wide item tooltips.

## Changes

**`AbPanel`** — two new static utility methods:
- `wrapText(String text, int maxWidth)` — word-wraps a single string into a `List<String>`, breaking on spaces at `maxWidth` characters
- `wrapLore(List<String> lore)` — wraps every entry in a lore list at `LORE_MAX_WIDTH` (35 chars) and returns a flat list

Applied in:
- **`AdminList`**: `getAdminDescription()` output is now wrapped before being added to the item lore
- **`EditUpgradePanel`**: upgrade description is wrapped when displayed on the Written Book item
- **`EditTierPanel`**: tier description is wrapped when displayed on the Written Book item

## Test plan

- [ ] `mvn test` passes (70 tests)
- [ ] Enter a long description for an upgrade and verify the lore breaks at word boundaries in the GUI
- [ ] Short descriptions (< 35 chars per line) are unaffected
- [ ] Price/reward descriptions in the tier price/reward list panels are wrapped

🤖 Generated with [Claude Code](https://claude.com/claude-code)