### PR TITLE
Remove old config-based upgrade system; fix DB upgrade level alignment

### DIFF
--- a/src/main/java/world/bentobox/upgrades/UpgradesAddon.java
+++ b/src/main/java/world/bentobox/upgrades/UpgradesAddon.java
@@ -36,11 +36,6 @@ import world.bentobox.upgrades.upgrades.DatabaseUpgrade;
 import world.bentobox.upgrades.listeners.IslandChangeListener;
 import world.bentobox.upgrades.listeners.JoinPermCheckListener;
 import world.bentobox.upgrades.ui.utils.ChatInput;
-import world.bentobox.upgrades.upgrades.BlockLimitsUpgrade;
-import world.bentobox.upgrades.upgrades.CommandUpgrade;
-import world.bentobox.upgrades.upgrades.EntityGroupLimitsUpgrade;
-import world.bentobox.upgrades.upgrades.EntityLimitsUpgrade;
-import world.bentobox.upgrades.upgrades.RangeUpgrade;
 
 public class UpgradesAddon extends Addon {
 
@@ -106,36 +101,13 @@ public class UpgradesAddon extends Addon {
                 this.logWarning("Vault plugin not found so Upgrades won't look for money");
             }
 
-            if (this.isLimitsProvided()) {
-                this.getSettings()
-                        .getEntityLimitsUpgrade()
-                        .forEach(ent -> this.registerUpgrade(new EntityLimitsUpgrade(this, ent)));
-                this.getSettings()
-                        .getEntityGroupLimitsUpgrade()
-                        .forEach(group -> this.registerUpgrade(
-                                new EntityGroupLimitsUpgrade(this, group)));
-                this.getSettings()
-                        .getMaterialsLimitsUpgrade()
-                        .forEach(mat -> this.registerUpgrade(new BlockLimitsUpgrade(this, mat)));
-
-                this.upgradesManager.addPrice(new IslandLevelPrice());
-            }
-
-            this.upgradesManager.addReward(new RangeReward());
+            this.upgradesManager.addPrice(new IslandLevelPrice());
             this.upgradesManager.addPrice(new MoneyPrice());
             this.upgradesManager.addPrice(new ItemPrice());
             this.upgradesManager.addPrice(new PermissionPrice());
+            this.upgradesManager.addReward(new RangeReward());
             this.upgradesManager.addReward(new LimitsReward());
             this.upgradesManager.addReward(new CommandReward());
-
-            this.getSettings()
-                    .getCommandUpgrade()
-                    .forEach(cmd -> this.registerUpgrade(new CommandUpgrade(this, cmd, this.getSettings()
-                            .getCommandIcon(cmd))));
-
-            if (this.getSettings()
-                    .getHasRangeUpgrade())
-                this.registerUpgrade(new RangeUpgrade(this));
 
             // Load database-backed upgrades
             this.hookedGameModes.forEach(gameModeName ->

--- a/src/main/java/world/bentobox/upgrades/dataobjects/UpgradesData.java
+++ b/src/main/java/world/bentobox/upgrades/dataobjects/UpgradesData.java
@@ -42,7 +42,7 @@ public class UpgradesData implements DataObject {
 	}
 	
 	public int getUpgradeLevel(String name) {
-		this.upgradesLevels.putIfAbsent(name, 1);
+		this.upgradesLevels.putIfAbsent(name, 0);
 		return this.upgradesLevels.get(name);
 	}
 	

--- a/src/main/java/world/bentobox/upgrades/dataobjects/prices/MoneyPrice.java
+++ b/src/main/java/world/bentobox/upgrades/dataobjects/prices/MoneyPrice.java
@@ -37,7 +37,14 @@ public class MoneyPrice extends Price {
 
     @Override
     public String getPublicDescription(User user) {
-        return user.getTranslation("upgrades.prices.money.description");
+        return user.getTranslation("upgrades.prices.money.description", "[amount]", "?");
+    }
+
+    @Override
+    public String getPublicDescription(User user, PriceDB priceDB) {
+        MoneyPriceDB db = (MoneyPriceDB) priceDB;
+        return user.getTranslation("upgrades.prices.money.description",
+                "[amount]", db.getAmountEquation());
     }
 
     @Override

--- a/src/main/java/world/bentobox/upgrades/dataobjects/prices/Price.java
+++ b/src/main/java/world/bentobox/upgrades/dataobjects/prices/Price.java
@@ -35,6 +35,16 @@ public abstract class Price implements PanelAdminItem, PanelPublicItem {
     public abstract AbPanel getAdminPanel(UpgradesAddon addon, GameModeAddon gamemode, User user,
                                           AbPanel parent, UpgradeTier tier, @Nullable PriceDB saved);
 
+    /**
+     * Returns a player-facing description with any formula placeholders substituted
+     * using values from the stored DB object.  Override in concrete Price types that
+     * carry a formula (e.g. MoneyPrice substitutes [amount]).
+     * The default falls back to {@link PanelPublicItem#getPublicDescription(User)}.
+     */
+    public String getPublicDescription(User user, PriceDB priceDB) {
+        return this.getPublicDescription(user);
+    }
+
     public abstract boolean canPay(UpgradesAddon addon, User user, Island island, PriceDB priceDB);
 
     public abstract void pay(UpgradesAddon addon, User user, Island island, PriceDB priceDB);

--- a/src/main/java/world/bentobox/upgrades/dataobjects/rewards/RangeReward.java
+++ b/src/main/java/world/bentobox/upgrades/dataobjects/rewards/RangeReward.java
@@ -49,6 +49,13 @@ public class RangeReward extends Reward {
     }
 
     @Override
+    public String getPublicDescription(User user, RewardDB rewardDB) {
+        RangeRewardDB db = (RangeRewardDB) rewardDB;
+        return user.getTranslation("upgrades.rewards.rangeupgrade.description",
+                "[rangelevel]", db.getRangeUpgradeEquation());
+    }
+
+    @Override
     public void apply(UpgradesAddon addon, User user, Island island, RewardDB rewardDB) {
         RangeRewardDB db = (RangeRewardDB) rewardDB;
         Map<String, Double> variables = new TreeMap<>();

--- a/src/main/java/world/bentobox/upgrades/dataobjects/rewards/Reward.java
+++ b/src/main/java/world/bentobox/upgrades/dataobjects/rewards/Reward.java
@@ -31,6 +31,16 @@ public abstract class Reward implements PanelAdminItem, PanelPublicItem {
         return this.icon;
     }
 
+    /**
+     * Returns a player-facing description with any formula placeholders substituted
+     * using values from the stored DB object.  Override in concrete Reward types that
+     * carry a formula (e.g. RangeReward substitutes the range amount).
+     * The default falls back to {@link PanelPublicItem#getPublicDescription(User)}.
+     */
+    public String getPublicDescription(User user, RewardDB rewardDB) {
+        return this.getPublicDescription(user);
+    }
+
     public abstract AbPanel getAdminPanel(UpgradesAddon addon, GameModeAddon gamemode, User user,
                                           AbPanel parent, UpgradeTier tier, @Nullable RewardDB saved);
 

--- a/src/main/java/world/bentobox/upgrades/ui/PanelClick.java
+++ b/src/main/java/world/bentobox/upgrades/ui/PanelClick.java
@@ -17,7 +17,14 @@ public class PanelClick implements ClickHandler {
 	
 	@Override
 	public boolean onClick(Panel panel, User user, ClickType clickType, int slot) {
-		if (this.upgrade == null || this.upgrade.getUpgradeValues(user) == null)
+		if (this.upgrade == null) return true;
+
+		// Block when truly maxed out:
+		//   Legacy upgrades: upgradeValues == null means maxed.
+		//   DB upgrades: upgradeValues is always null; ownDescription == null means maxed.
+		// An upgrade is available if EITHER signal is non-null.
+		if (this.upgrade.getUpgradeValues(user) == null
+				&& this.upgrade.getOwnDescription(user) == null)
 			return true;
 		
 		if (!this.upgrade.canUpgrade(user, this.island)) {

--- a/src/main/java/world/bentobox/upgrades/ui/admin/AdminPanel.java
+++ b/src/main/java/world/bentobox/upgrades/ui/admin/AdminPanel.java
@@ -108,6 +108,11 @@ public class AdminPanel extends AbPanel {
 		newUpgrade.setName(input);
 		this.getAddon().getUpgradeDataManager().saveUpgradeData(newUpgrade);
 
+		// Register the new upgrade in the player-facing shop immediately.
+		// Without this call the upgrade lives in the DB but is never added to
+		// addon.upgrade, so /is upgrade shows nothing for it.
+		this.getAddon().refreshDatabaseUpgrades();
+
 		new EditUpgradePanel(this.getAddon(), this.getGamemode(), this.getUser(), newUpgrade, this)
 				.getBuild().build();
 	};

--- a/src/main/java/world/bentobox/upgrades/upgrades/DatabaseUpgrade.java
+++ b/src/main/java/world/bentobox/upgrades/upgrades/DatabaseUpgrade.java
@@ -42,23 +42,28 @@ public class DatabaseUpgrade extends UpgradeAPI {
             return;
         }
 
-        // Build description from prices and rewards
+        // Build description from prices and rewards, using DB-aware overloads so that
+        // formula placeholders (e.g. [amount] in MoneyPrice) are substituted correctly.
         StringBuilder sb = new StringBuilder();
         for (PriceDB priceDB : nextTier.getPrices()) {
             Price price = this.getUpgradesAddon().getUpgradesManager().searchPrice(priceDB.getPriceType());
             if (price != null) {
-                sb.append(price.getPublicDescription(user)).append("\n");
+                sb.append(price.getPublicDescription(user, priceDB)).append("\n");
             }
         }
         for (RewardDB rewardDB : nextTier.getRewards()) {
             Reward reward = this.getUpgradesAddon().getUpgradesManager().searchReward(rewardDB.getRewardType());
             if (reward != null) {
-                sb.append(reward.getPublicDescription(user)).append("\n");
+                sb.append(reward.getPublicDescription(user, rewardDB)).append("\n");
             }
         }
 
         String description = sb.toString().trim();
-        this.setOwnDescription(user, description.isEmpty() ? null : description);
+        // Always set a non-null ownDescription when a tier is found.
+        // PanelClick uses (upgradeValues == null && ownDescription == null) to detect
+        // the maxed-out state, so ownDescription must be non-null here even when the
+        // tier has no prices or rewards configured (free upgrade).
+        this.setOwnDescription(user, description.isEmpty() ? nextTier.getName() : description);
         // Do NOT set upgradeValues so Panel skips legacy vault/level display
         this.setUpgradeValues(user, null);
         this.setDisplayName(upgradeData.getName());

--- a/src/main/java/world/bentobox/upgrades/upgrades/DatabaseUpgrade.java
+++ b/src/main/java/world/bentobox/upgrades/upgrades/DatabaseUpgrade.java
@@ -121,14 +121,14 @@ public class DatabaseUpgrade extends UpgradeAPI {
     }
 
     /**
-     * Find the tier that covers the next level (currentLevel + 1).
+     * Find the tier that covers the current level (i.e. the next purchase available).
+     * Level 0 = not yet purchased; a tier with startLevel=0, endLevel=0 means one purchase.
      */
     private UpgradeTier findNextTier(int currentLevel) {
-        int nextLevel = currentLevel + 1;
         List<UpgradeTier> tiers = this.getUpgradesAddon().getUpgradeDataManager()
                 .getUpgradeTierByUpgradeData(upgradeData);
         for (UpgradeTier tier : tiers) {
-            if (tier.getStartLevel() <= nextLevel && nextLevel <= tier.getEndLevel()) {
+            if (tier.getStartLevel() <= currentLevel && currentLevel <= tier.getEndLevel()) {
                 return tier;
             }
         }

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -168,8 +168,7 @@ upgrades:
   rewards:
     rangeupgrade:
       name: "Range upgrade"
-      description: |-
-        Increase the border size
+      description: "Increase border by [rangelevel] blocks"
       admindescription: |-
         Increase the island border size
         Careful to not go over the island limit

--- a/src/test/java/world/bentobox/upgrades/dataobjects/UpgradesDataTest.java
+++ b/src/test/java/world/bentobox/upgrades/dataobjects/UpgradesDataTest.java
@@ -1,0 +1,77 @@
+package world.bentobox.upgrades.dataobjects;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link UpgradesData} — per-island upgrade level storage.
+ *
+ * Critical invariant: getUpgradeLevel() must return 0 for a key that has
+ * never been set.  If it returned 1 (the old broken default), a tier
+ * with startLevel=0..endLevel=0 would never match because findNextTier()
+ * would see currentLevel=0 and the check 0<=0<=0 is true, but with the
+ * old default of 1, it would see currentLevel=1 and 0<=1<=0 is false —
+ * causing every DB upgrade to appear permanently maxed on a fresh island.
+ */
+public class UpgradesDataTest {
+
+    private static final String KEY = "BSkyBlock_diamond";
+    private static final String ISLAND_ID = "island-uuid-1234";
+
+    private UpgradesData upgradesData;
+
+    @BeforeEach
+    void setUp() {
+        upgradesData = new UpgradesData(ISLAND_ID);
+    }
+
+    @Test
+    void getUniqueId_returnsConstructorValue() {
+        assertEquals(ISLAND_ID, upgradesData.getUniqueId());
+    }
+
+    @Test
+    void getUpgradeLevel_freshKey_returnsZeroNotOne() {
+        // This is the core regression test: the level must start at 0 so that
+        // a tier configured as startLevel=0, endLevel=0 is immediately purchasable.
+        assertEquals(0, upgradesData.getUpgradeLevel(KEY),
+                "Fresh island upgrade level must be 0 — returning 1 would make all DB upgrades appear permanently maxed");
+    }
+
+    @Test
+    void getUpgradeLevel_calledTwice_staysAtZero() {
+        // putIfAbsent must not overwrite an existing 0 on the second call.
+        assertEquals(0, upgradesData.getUpgradeLevel(KEY));
+        assertEquals(0, upgradesData.getUpgradeLevel(KEY));
+    }
+
+    @Test
+    void setAndGet_roundTrip() {
+        upgradesData.setUpgradeLevel(KEY, 5);
+        assertEquals(5, upgradesData.getUpgradeLevel(KEY));
+    }
+
+    @Test
+    void setUpgradeLevel_toZero_returnsZero() {
+        upgradesData.setUpgradeLevel(KEY, 3);
+        upgradesData.setUpgradeLevel(KEY, 0);
+        assertEquals(0, upgradesData.getUpgradeLevel(KEY));
+    }
+
+    @Test
+    void differentUpgradesStoredIndependently() {
+        upgradesData.setUpgradeLevel("upgrade_a", 2);
+        upgradesData.setUpgradeLevel("upgrade_b", 7);
+        assertEquals(2, upgradesData.getUpgradeLevel("upgrade_a"));
+        assertEquals(7, upgradesData.getUpgradeLevel("upgrade_b"));
+    }
+
+    @Test
+    void getUpgradeLevel_afterSetToZero_doesNotResetToDefault() {
+        // Explicitly set to 0, then read again — must NOT re-insert the default.
+        upgradesData.setUpgradeLevel(KEY, 0);
+        assertEquals(0, upgradesData.getUpgradeLevel(KEY));
+    }
+}

--- a/src/test/java/world/bentobox/upgrades/upgrades/DatabaseUpgradeTest.java
+++ b/src/test/java/world/bentobox/upgrades/upgrades/DatabaseUpgradeTest.java
@@ -1,0 +1,317 @@
+package world.bentobox.upgrades.upgrades;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.bukkit.World;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import world.bentobox.bentobox.BentoBox;
+import world.bentobox.bentobox.api.addons.AddonDescription;
+import world.bentobox.bentobox.api.addons.GameModeAddon;
+import world.bentobox.bentobox.api.user.User;
+import world.bentobox.bentobox.database.objects.Island;
+import world.bentobox.bentobox.managers.IslandWorldManager;
+import world.bentobox.upgrades.UpgradesAddon;
+import world.bentobox.upgrades.UpgradesDataManager;
+import world.bentobox.upgrades.UpgradesManager;
+import world.bentobox.upgrades.dataobjects.UpgradeData;
+import world.bentobox.upgrades.dataobjects.UpgradeTier;
+import world.bentobox.upgrades.dataobjects.UpgradesData;
+import world.bentobox.upgrades.dataobjects.prices.Price;
+import world.bentobox.upgrades.dataobjects.prices.PriceDB;
+import world.bentobox.upgrades.dataobjects.rewards.Reward;
+import world.bentobox.upgrades.dataobjects.rewards.RewardDB;
+
+/**
+ * Tests for {@link DatabaseUpgrade} — the bridge between admin-GUI-configured
+ * upgrades and the player shop.
+ *
+ * Key invariants under test:
+ *  - Fresh island level is 0, so a tier at startLevel=0..endLevel=0 is
+ *    immediately purchasable (regression test for the putIfAbsent(1) bug).
+ *  - After one purchase the level becomes 1; a 0-0 tier no longer matches,
+ *    so the upgrade shows as "Max level".
+ *  - isShowed() gates on active flag, non-empty tier list, and game-mode match.
+ *  - canUpgrade() delegates to each Price.canPay().
+ *  - doUpgrade() calls Price.pay(), Reward.apply(), and increments the level.
+ */
+public class DatabaseUpgradeTest {
+
+    @Mock private UpgradesAddon addon;
+    @Mock private BentoBox plugin;
+    @Mock private IslandWorldManager iwm;
+    @Mock private UpgradesDataManager upgradesDataManager;
+    @Mock private UpgradesManager upgradesManager;
+    @Mock private User user;
+    @Mock private Island island;
+    @Mock private World world;
+    @Mock private GameModeAddon gameModeAddon;
+    @Mock private AddonDescription gameModeDesc;
+
+    private UpgradeData upgradeData;
+    /** A single-purchase tier: startLevel=0, endLevel=0 */
+    private UpgradeTier tier;
+    private UpgradesData upgradesData;
+    private DatabaseUpgrade databaseUpgrade;
+    private String islandId;
+    private UUID userId;
+
+    @BeforeEach
+    void setUp() {
+        MockBukkit.mock();
+        MockitoAnnotations.openMocks(this);
+
+        userId = UUID.randomUUID();
+        islandId = UUID.randomUUID().toString();
+
+        // Upgrade configured for BSkyBlock
+        upgradeData = new UpgradeData();
+        upgradeData.setUniqueId("BSkyBlock_diamond");
+        upgradeData.setWorld("BSkyBlock");
+        upgradeData.setName("Diamond Upgrade");
+        upgradeData.setActive(true);
+
+        // Single-purchase tier: one buy available (level 0 → 1)
+        tier = new UpgradeTier();
+        tier.setUniqueId("BSkyBlock_diamond_t1");
+        tier.setUpgrade("BSkyBlock_diamond");
+        tier.setName("Tier 1");
+        tier.setStartLevel(0);
+        tier.setEndLevel(0);
+
+        // Fresh island data — must default to level 0
+        upgradesData = new UpgradesData(islandId);
+
+        when(user.getUniqueId()).thenReturn(userId);
+        when(user.getTranslation(any(String.class)))
+                .thenAnswer(inv -> inv.getArgument(0, String.class));
+        when(island.getUniqueId()).thenReturn(islandId);
+        when(island.getWorld()).thenReturn(world);
+
+        // addon → plugin → IWM → game-mode lookup
+        when(addon.getPlugin()).thenReturn(plugin);
+        when(plugin.getIWM()).thenReturn(iwm);
+        when(iwm.getAddon(world)).thenReturn(Optional.of(gameModeAddon));
+        when(gameModeAddon.getDescription()).thenReturn(gameModeDesc);
+        when(gameModeDesc.getName()).thenReturn("BSkyBlock");
+
+        when(addon.getUpgradeDataManager()).thenReturn(upgradesDataManager);
+        when(addon.getUpgradesManager()).thenReturn(upgradesManager);
+        when(addon.getUpgradesLevels(islandId)).thenReturn(upgradesData);
+        when(upgradesDataManager.getUpgradeTierByUpgradeData(upgradeData))
+                .thenReturn(Collections.singletonList(tier));
+
+        databaseUpgrade = new DatabaseUpgrade(addon, upgradeData);
+    }
+
+    @AfterEach
+    void tearDown() {
+        MockBukkit.unmock();
+    }
+
+    // ─── isShowed() ───────────────────────────────────────────────────────
+
+    @Test
+    void isShowed_inactiveUpgrade_returnsFalse() {
+        upgradeData.setActive(false);
+        assertFalse(databaseUpgrade.isShowed(user, island));
+    }
+
+    @Test
+    void isShowed_noTiersConfigured_returnsFalse() {
+        // An upgrade with no tiers would appear permanently maxed; hide it.
+        when(upgradesDataManager.getUpgradeTierByUpgradeData(upgradeData))
+                .thenReturn(Collections.emptyList());
+        assertFalse(databaseUpgrade.isShowed(user, island));
+    }
+
+    @Test
+    void isShowed_wrongGameMode_returnsFalse() {
+        when(gameModeDesc.getName()).thenReturn("AcidIsland");
+        assertFalse(databaseUpgrade.isShowed(user, island));
+    }
+
+    @Test
+    void isShowed_gameModeWorldNotFound_returnsFalse() {
+        when(iwm.getAddon(world)).thenReturn(Optional.empty());
+        assertFalse(databaseUpgrade.isShowed(user, island));
+    }
+
+    @Test
+    void isShowed_allConditionsMet_returnsTrue() {
+        assertTrue(databaseUpgrade.isShowed(user, island));
+    }
+
+    // ─── Level storage (UpgradesData) ─────────────────────────────────────
+    //
+    // These tests confirm the fix: getUpgradeLevel() must start at 0, not 1.
+    // A tier with startLevel=0..endLevel=0 must be reachable on a fresh island.
+
+    @Test
+    void freshIsland_levelStartsAtZero_notOne() {
+        assertEquals(0, upgradesData.getUpgradeLevel("BSkyBlock_diamond"),
+                "Fresh island must start at level 0 so tier 0-0 is immediately purchasable");
+    }
+
+    @Test
+    void setAndGetUpgradeLevel_roundTrip() {
+        upgradesData.setUpgradeLevel("BSkyBlock_diamond", 3);
+        assertEquals(3, upgradesData.getUpgradeLevel("BSkyBlock_diamond"));
+    }
+
+    // ─── updateUpgradeValue() / tier resolution ────────────────────────────
+
+    @Test
+    void updateUpgradeValue_freshIsland_tierFound_upgradeIsVisible() {
+        // Level 0: tier 0-0 must match (0 <= 0 <= 0) so upgrade appears in shop.
+        databaseUpgrade.updateUpgradeValue(user, island);
+        assertTrue(databaseUpgrade.isShowed(user, island));
+    }
+
+    @Test
+    void updateUpgradeValue_afterOnePurchase_bothNullMeansMaxLevel() {
+        // Level 1: tier 0-0 no longer matches (0 <= 1 <= 0 is FALSE).
+        // Both ownDescription and upgradeValues are set to null → Panel shows "Max level".
+        upgradesData.setUpgradeLevel(upgradeData.getUniqueId(), 1);
+        databaseUpgrade.updateUpgradeValue(user, island);
+
+        assertNull(databaseUpgrade.getUpgradeValues(user),
+                "upgradeValues must be null when no tier covers the current level");
+        assertNull(databaseUpgrade.getOwnDescription(user),
+                "ownDescription must be null when no tier covers the current level");
+    }
+
+    @Test
+    void updateUpgradeValue_multiLevelTier_midPointIsStillBuyable() {
+        // Tier 0-2: three purchases; level 1 is still within range.
+        tier.setEndLevel(2);
+        upgradesData.setUpgradeLevel(upgradeData.getUniqueId(), 1);
+        databaseUpgrade.updateUpgradeValue(user, island);
+
+        assertTrue(databaseUpgrade.isShowed(user, island));
+    }
+
+    @Test
+    void updateUpgradeValue_multiLevelTier_pastEndIsMaxed() {
+        // Tier 0-2 but level is 3: past the end, should appear maxed.
+        tier.setEndLevel(2);
+        upgradesData.setUpgradeLevel(upgradeData.getUniqueId(), 3);
+        databaseUpgrade.updateUpgradeValue(user, island);
+
+        assertNull(databaseUpgrade.getUpgradeValues(user));
+        assertNull(databaseUpgrade.getOwnDescription(user));
+    }
+
+    // ─── canUpgrade() ────────────────────────────────────────────────────
+
+    @Test
+    void canUpgrade_noTierFound_returnsFalse() {
+        // Level 1 on a 0-0 tier: already maxed, cannot upgrade.
+        upgradesData.setUpgradeLevel(upgradeData.getUniqueId(), 1);
+        assertFalse(databaseUpgrade.canUpgrade(user, island));
+    }
+
+    @Test
+    void canUpgrade_noPricesOnTier_returnsTrue() {
+        // No prices configured → free upgrade → always purchasable.
+        assertTrue(databaseUpgrade.canUpgrade(user, island));
+    }
+
+    @Test
+    void canUpgrade_priceCheckPasses_returnsTrue() {
+        PriceDB priceDB = mock(PriceDB.class);
+        Price price = mock(Price.class);
+        when(upgradesManager.searchPrice(any())).thenReturn(price);
+        when(price.canPay(addon, user, island, priceDB)).thenReturn(true);
+        tier.setPrices(List.of(priceDB));
+
+        assertTrue(databaseUpgrade.canUpgrade(user, island));
+    }
+
+    @Test
+    void canUpgrade_priceCheckFails_returnsFalse() {
+        PriceDB priceDB = mock(PriceDB.class);
+        Price price = mock(Price.class);
+        when(upgradesManager.searchPrice(any())).thenReturn(price);
+        when(price.canPay(addon, user, island, priceDB)).thenReturn(false);
+        tier.setPrices(List.of(priceDB));
+
+        assertFalse(databaseUpgrade.canUpgrade(user, island));
+    }
+
+    @Test
+    void canUpgrade_nullPriceFromManager_skippedAndReturnsTrue() {
+        // searchPrice returns null (unregistered type) → price is skipped, not a failure.
+        PriceDB priceDB = mock(PriceDB.class);
+        when(upgradesManager.searchPrice(any())).thenReturn(null);
+        tier.setPrices(List.of(priceDB));
+
+        assertTrue(databaseUpgrade.canUpgrade(user, island));
+    }
+
+    // ─── doUpgrade() ─────────────────────────────────────────────────────
+
+    @Test
+    void doUpgrade_noTierFound_returnsFalse() {
+        upgradesData.setUpgradeLevel(upgradeData.getUniqueId(), 1); // already maxed
+        assertFalse(databaseUpgrade.doUpgrade(user, island));
+    }
+
+    @Test
+    void doUpgrade_incrementsLevelByOne() {
+        assertEquals(0, upgradesData.getUpgradeLevel(upgradeData.getUniqueId()));
+
+        boolean result = databaseUpgrade.doUpgrade(user, island);
+
+        assertTrue(result);
+        assertEquals(1, upgradesData.getUpgradeLevel(upgradeData.getUniqueId()));
+    }
+
+    @Test
+    void doUpgrade_callsPricePayAndRewardApply() {
+        PriceDB priceDB = mock(PriceDB.class);
+        Price price = mock(Price.class);
+        when(upgradesManager.searchPrice(any())).thenReturn(price);
+        tier.setPrices(List.of(priceDB));
+
+        RewardDB rewardDB = mock(RewardDB.class);
+        Reward reward = mock(Reward.class);
+        when(upgradesManager.searchReward(any())).thenReturn(reward);
+        tier.setRewards(List.of(rewardDB));
+
+        databaseUpgrade.doUpgrade(user, island);
+
+        verify(price).pay(addon, user, island, priceDB);
+        verify(reward).apply(addon, user, island, rewardDB);
+    }
+
+    @Test
+    void doUpgrade_afterMaxing_secondCallReturnsFalse() {
+        // First purchase: level 0 → 1, tier 0-0 consumed.
+        assertTrue(databaseUpgrade.doUpgrade(user, island));
+        // Second call: level 1, no tier covers it.
+        assertFalse(databaseUpgrade.doUpgrade(user, island));
+    }
+
+    @Test
+    void doUpgrade_nullRewardFromManager_skippedGracefully() {
+        RewardDB rewardDB = mock(RewardDB.class);
+        when(upgradesManager.searchReward(any())).thenReturn(null);
+        tier.setRewards(List.of(rewardDB));
+
+        assertTrue(databaseUpgrade.doUpgrade(user, island));
+        assertEquals(1, upgradesData.getUpgradeLevel(upgradeData.getUniqueId()));
+    }
+}

--- a/src/test/java/world/bentobox/upgrades/upgrades/DatabaseUpgradeTest.java
+++ b/src/test/java/world/bentobox/upgrades/upgrades/DatabaseUpgradeTest.java
@@ -314,4 +314,63 @@ public class DatabaseUpgradeTest {
         assertTrue(databaseUpgrade.doUpgrade(user, island));
         assertEquals(1, upgradesData.getUpgradeLevel(upgradeData.getUniqueId()));
     }
+
+    // ─── PanelClick gating regression ─────────────────────────────────────
+    //
+    // DB upgrades never populate upgradeValues (it stays null by design).
+    // PanelClick used to check only getUpgradeValues(user) == null, which
+    // silently blocked every DB upgrade click.  The fix: treat
+    //   (upgradeValues == null && ownDescription == null) as "maxed".
+    // So ownDescription must be non-null whenever a tier is found.
+
+    @Test
+    void updateUpgradeValue_withPricesAndRewards_ownDescriptionIsNonNull() {
+        PriceDB priceDB = mock(PriceDB.class);
+        Price price = mock(Price.class);
+        when(upgradesManager.searchPrice(any())).thenReturn(price);
+        when(price.getPublicDescription(eq(user), eq(priceDB))).thenReturn("Costs 100 money");
+        tier.setPrices(List.of(priceDB));
+
+        databaseUpgrade.updateUpgradeValue(user, island);
+
+        assertNotNull(databaseUpgrade.getOwnDescription(user),
+                "ownDescription must not be null when a tier is found — PanelClick uses null ownDescription to block clicks");
+    }
+
+    @Test
+    void updateUpgradeValue_noPricesOrRewards_ownDescriptionFallsBackToTierName() {
+        // A tier with no prices or rewards: description should be tier name so that
+        // PanelClick can distinguish "available free upgrade" from "maxed".
+        databaseUpgrade.updateUpgradeValue(user, island);
+
+        assertEquals(tier.getName(), databaseUpgrade.getOwnDescription(user),
+                "ownDescription must fall back to tier name when there are no price/reward descriptions");
+    }
+
+    @Test
+    void updateUpgradeValue_maxedState_ownDescriptionIsNull() {
+        // Level 1 with tier 0-0: maxed → ownDescription must be null so PanelClick blocks the click.
+        upgradesData.setUpgradeLevel(upgradeData.getUniqueId(), 1);
+        databaseUpgrade.updateUpgradeValue(user, island);
+
+        assertNull(databaseUpgrade.getOwnDescription(user),
+                "ownDescription must be null when maxed so PanelClick correctly blocks the click");
+    }
+
+    // ─── Description substitution ─────────────────────────────────────────
+
+    @Test
+    void updateUpgradeValue_moneyPrice_substitutesAmountInDescription() {
+        PriceDB priceDB = mock(PriceDB.class);
+        Price price = mock(Price.class);
+        when(upgradesManager.searchPrice(any())).thenReturn(price);
+        // Simulate MoneyPrice.getPublicDescription(user, priceDB) returning "Costs 500 money"
+        when(price.getPublicDescription(user, priceDB)).thenReturn("Costs 500 money");
+        tier.setPrices(List.of(priceDB));
+
+        databaseUpgrade.updateUpgradeValue(user, island);
+
+        assertTrue(databaseUpgrade.getOwnDescription(user).contains("Costs 500 money"),
+                "Description must use the DB-aware overload that substitutes [amount]");
+    }
 }


### PR DESCRIPTION
## Summary

- **Fixes #68**: Remove all config-based upgrade registrations (`RangeUpgrade`, `BlockLimitsUpgrade`, `EntityLimitsUpgrade`, `EntityGroupLimitsUpgrade`, `CommandUpgrade`) from `UpgradesAddon.onEnable()`. The player shop (`/is upgrade`) now only shows upgrades created through the admin GUI.
- **Fixes #71**: Two-part fix for DB upgrades never appearing in the player shop:
  1. `UpgradesData.getUpgradeLevel()` now starts at `0` instead of `1` — a fresh island has no purchases yet.
  2. `DatabaseUpgrade.findNextTier()` now matches `currentLevel` directly (not `currentLevel + 1`). A tier with `startLevel=0, endLevel=0` (one-shot upgrade) correctly shows for a fresh island (level 0) and disappears after purchase (level 1).
- `IslandLevelPrice` is now registered unconditionally (moved out of the `isLimitsProvided()` guard) so it's always available as a price type in the admin GUI.

## Test plan

- [ ] All 70 existing tests pass (`mvn test`)
- [ ] Admin creates an upgrade via `/bsb admin upgrade`, adds a tier (default 0–0), adds prices/rewards
- [ ] Player opens `/bsb upgrade` — the new upgrade appears in the shop
- [ ] Player purchases — tier is consumed, upgrade disappears (max level reached)
- [ ] Old config-based upgrades no longer appear in the player shop
- [ ] `IslandLevelPrice` selectable in admin GUI price list regardless of whether Limits is installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)