### PR TITLE
Add 6 example upgrades seeded on first install

### DIFF
--- a/src/main/java/world/bentobox/upgrades/DefaultUpgradeSeeder.java
+++ b/src/main/java/world/bentobox/upgrades/DefaultUpgradeSeeder.java
@@ -1,0 +1,225 @@
+package world.bentobox.upgrades;
+
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+
+import world.bentobox.upgrades.dataobjects.UpgradeData;
+import world.bentobox.upgrades.dataobjects.UpgradeTier;
+import world.bentobox.upgrades.dataobjects.prices.IslandLevelPriceDB;
+import world.bentobox.upgrades.dataobjects.prices.ItemPriceDB;
+import world.bentobox.upgrades.dataobjects.prices.MoneyPriceDB;
+import world.bentobox.upgrades.dataobjects.prices.PermissionPriceDB;
+import world.bentobox.upgrades.dataobjects.rewards.CommandRewardDB;
+import world.bentobox.upgrades.dataobjects.rewards.LimitsRewardDB;
+import world.bentobox.upgrades.dataobjects.rewards.RangeRewardDB;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Seeds 6 example upgrades for each hooked game mode on first install.
+ * Skips any game mode that already has at least one configured upgrade.
+ */
+public class DefaultUpgradeSeeder {
+
+    private final UpgradesAddon addon;
+
+    public DefaultUpgradeSeeder(UpgradesAddon addon) {
+        this.addon = addon;
+    }
+
+    /**
+     * For each hooked game mode that has no upgrades configured, seed examples.
+     */
+    public void seedIfEmpty() {
+        UpgradesDataManager dm = addon.getUpgradeDataManager();
+        for (String gm : addon.getHookedGameModes()) {
+            if (dm.getUpgradeDataByGameMode(gm).isEmpty()) {
+                seed(dm, gm);
+                addon.log("Seeded 6 example upgrades for " + gm
+                        + " — edit or delete them via /[gamemode] admin upgrade");
+            }
+        }
+    }
+
+    private void seed(UpgradesDataManager dm, String gm) {
+        seedBorderBasic(dm, gm);
+        seedBorderAdvanced(dm, gm);
+        seedHopperLimit(dm, gm);
+        seedCowLimit(dm, gm);
+        seedDiamondBorder(dm, gm);
+        seedDonorPerk(dm, gm);
+    }
+
+    // ─── Example 1: Border Expansion I ───────────────────────────────────────
+    // Demonstrates: simple MoneyPrice → RangeReward (5 purchases available)
+
+    private void seedBorderBasic(UpgradesDataManager dm, String gm) {
+        UpgradeData data = dm.createUpgradeData(gm + "_example_range1", gm, null);
+        if (data == null) return;
+        data.setName("Border Expansion I");
+        data.setIcon(new ItemStack(Material.OAK_FENCE));
+        data.setOrder(1);
+        data.setDescription(List.of("Example: pay $500 to expand island border by 5 blocks. Up to 5 times."));
+        dm.saveUpgradeData(data);
+
+        UpgradeTier tier = dm.createUpgradeTier(gm + "_example_range1_t1", data, 0, 4, null);
+        if (tier == null) return;
+        tier.setName("Border Expansion I");
+
+        MoneyPriceDB money = new MoneyPriceDB();
+        money.setAmountEquation("500");
+        tier.setPrices(List.of(money));
+
+        RangeRewardDB range = new RangeRewardDB();
+        range.setRangeUpgradeEquation("5");
+        tier.setRewards(List.of(range));
+
+        dm.saveUpgradeTier(tier);
+    }
+
+    // ─── Example 2: Border Expansion II ──────────────────────────────────────
+    // Demonstrates: IslandLevelPrice gate + MoneyPrice → RangeReward (3 purchases)
+
+    private void seedBorderAdvanced(UpgradesDataManager dm, String gm) {
+        UpgradeData data = dm.createUpgradeData(gm + "_example_range2", gm, null);
+        if (data == null) return;
+        data.setName("Border Expansion II");
+        data.setIcon(new ItemStack(Material.IRON_BARS));
+        data.setOrder(2);
+        data.setDescription(List.of("Example: requires island level 100 and costs $2000. Up to 3 times."));
+        dm.saveUpgradeData(data);
+
+        UpgradeTier tier = dm.createUpgradeTier(gm + "_example_range2_t1", data, 0, 2, null);
+        if (tier == null) return;
+        tier.setName("Border Expansion II");
+
+        IslandLevelPriceDB level = new IslandLevelPriceDB();
+        level.setLevelNeededEquation("100");
+        MoneyPriceDB money = new MoneyPriceDB();
+        money.setAmountEquation("2000");
+        tier.setPrices(List.of(level, money));
+
+        RangeRewardDB range = new RangeRewardDB();
+        range.setRangeUpgradeEquation("10");
+        tier.setRewards(List.of(range));
+
+        dm.saveUpgradeTier(tier);
+    }
+
+    // ─── Example 3: Hopper Limit ──────────────────────────────────────────────
+    // Demonstrates: MoneyPrice → LimitsReward (BLOCK) (5 purchases)
+
+    private void seedHopperLimit(UpgradesDataManager dm, String gm) {
+        UpgradeData data = dm.createUpgradeData(gm + "_example_hopper", gm, null);
+        if (data == null) return;
+        data.setName("Hopper Limit");
+        data.setIcon(new ItemStack(Material.HOPPER));
+        data.setOrder(3);
+        data.setDescription(List.of("Example: pay $1000 to increase your hopper limit by 2. Up to 5 times."));
+        dm.saveUpgradeData(data);
+
+        UpgradeTier tier = dm.createUpgradeTier(gm + "_example_hopper_t1", data, 0, 4, null);
+        if (tier == null) return;
+        tier.setName("Hopper Limit");
+
+        MoneyPriceDB money = new MoneyPriceDB();
+        money.setAmountEquation("1000");
+        tier.setPrices(List.of(money));
+
+        LimitsRewardDB limits = new LimitsRewardDB();
+        limits.setLimitType("BLOCK");
+        limits.setTarget("HOPPER");
+        limits.setAmountEquation("2");
+        tier.setRewards(List.of(limits));
+
+        dm.saveUpgradeTier(tier);
+    }
+
+    // ─── Example 4: Cow Limit ─────────────────────────────────────────────────
+    // Demonstrates: MoneyPrice → LimitsReward (ENTITY) (5 purchases)
+
+    private void seedCowLimit(UpgradesDataManager dm, String gm) {
+        UpgradeData data = dm.createUpgradeData(gm + "_example_cow", gm, null);
+        if (data == null) return;
+        data.setName("Cow Limit");
+        data.setIcon(new ItemStack(Material.BEEF));
+        data.setOrder(4);
+        data.setDescription(List.of("Example: pay $500 to increase your cow entity limit by 2. Up to 5 times."));
+        dm.saveUpgradeData(data);
+
+        UpgradeTier tier = dm.createUpgradeTier(gm + "_example_cow_t1", data, 0, 4, null);
+        if (tier == null) return;
+        tier.setName("Cow Limit");
+
+        MoneyPriceDB money = new MoneyPriceDB();
+        money.setAmountEquation("500");
+        tier.setPrices(List.of(money));
+
+        LimitsRewardDB limits = new LimitsRewardDB();
+        limits.setLimitType("ENTITY");
+        limits.setTarget("COW");
+        limits.setAmountEquation("2");
+        tier.setRewards(List.of(limits));
+
+        dm.saveUpgradeTier(tier);
+    }
+
+    // ─── Example 5: Diamond Border ────────────────────────────────────────────
+    // Demonstrates: ItemPrice → RangeReward (3 purchases)
+
+    private void seedDiamondBorder(UpgradesDataManager dm, String gm) {
+        UpgradeData data = dm.createUpgradeData(gm + "_example_diamond", gm, null);
+        if (data == null) return;
+        data.setName("Diamond Border");
+        data.setIcon(new ItemStack(Material.DIAMOND));
+        data.setOrder(5);
+        data.setDescription(List.of("Example: spend 10 diamonds to expand island border by 3 blocks. Up to 3 times."));
+        dm.saveUpgradeData(data);
+
+        UpgradeTier tier = dm.createUpgradeTier(gm + "_example_diamond_t1", data, 0, 2, null);
+        if (tier == null) return;
+        tier.setName("Diamond Border");
+
+        ItemPriceDB item = new ItemPriceDB();
+        item.setMaterial("DIAMOND");
+        item.setAmount(10);
+        tier.setPrices(List.of(item));
+
+        RangeRewardDB range = new RangeRewardDB();
+        range.setRangeUpgradeEquation("3");
+        tier.setRewards(List.of(range));
+
+        dm.saveUpgradeTier(tier);
+    }
+
+    // ─── Example 6: Donor Perk ────────────────────────────────────────────────
+    // Demonstrates: PermissionPrice (gate) → CommandReward (one-time purchase)
+
+    private void seedDonorPerk(UpgradesDataManager dm, String gm) {
+        UpgradeData data = dm.createUpgradeData(gm + "_example_donor", gm, null);
+        if (data == null) return;
+        data.setName("Donor Perk");
+        data.setIcon(new ItemStack(Material.NETHER_STAR));
+        data.setOrder(6);
+        data.setDescription(List.of("Example: requires the upgrades.example.donor permission. Runs a console command on purchase."));
+        dm.saveUpgradeData(data);
+
+        UpgradeTier tier = dm.createUpgradeTier(gm + "_example_donor_t1", data, 0, 0, null);
+        if (tier == null) return;
+        tier.setName("Donor Perk");
+
+        PermissionPriceDB perm = new PermissionPriceDB();
+        perm.setPermission("upgrades.example.donor");
+        tier.setPrices(List.of(perm));
+
+        CommandRewardDB cmd = new CommandRewardDB();
+        List<String> commands = new ArrayList<>();
+        commands.add("say [player] has unlocked the Donor Perk on their island!");
+        cmd.setCommands(commands);
+        cmd.setConsole(true);
+        tier.setRewards(List.of(cmd));
+
+        dm.saveUpgradeTier(tier);
+    }
+}

--- a/src/main/java/world/bentobox/upgrades/UpgradesAddon.java
+++ b/src/main/java/world/bentobox/upgrades/UpgradesAddon.java
@@ -1,6 +1,7 @@
 package world.bentobox.upgrades;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -32,6 +33,7 @@ import world.bentobox.upgrades.dataobjects.prices.PermissionPrice;
 import world.bentobox.upgrades.dataobjects.rewards.CommandReward;
 import world.bentobox.upgrades.dataobjects.rewards.LimitsReward;
 import world.bentobox.upgrades.dataobjects.rewards.RangeReward;
+import world.bentobox.upgrades.DefaultUpgradeSeeder;
 import world.bentobox.upgrades.upgrades.DatabaseUpgrade;
 import world.bentobox.upgrades.listeners.IslandChangeListener;
 import world.bentobox.upgrades.listeners.JoinPermCheckListener;
@@ -108,6 +110,9 @@ public class UpgradesAddon extends Addon {
             this.upgradesManager.addReward(new RangeReward());
             this.upgradesManager.addReward(new LimitsReward());
             this.upgradesManager.addReward(new CommandReward());
+
+            // Seed example upgrades for any game mode that has none yet
+            new DefaultUpgradeSeeder(this).seedIfEmpty();
 
             // Load database-backed upgrades
             this.hookedGameModes.forEach(gameModeName ->
@@ -222,6 +227,10 @@ public class UpgradesAddon extends Addon {
 
     public boolean isVaultProvided() {
         return this.vault != null;
+    }
+
+    public List<String> getHookedGameModes() {
+        return Collections.unmodifiableList(hookedGameModes);
     }
 
     public Set<UpgradeAPI> getAvailableUpgrades() {

--- a/src/main/java/world/bentobox/upgrades/dataobjects/prices/IslandLevelPrice.java
+++ b/src/main/java/world/bentobox/upgrades/dataobjects/prices/IslandLevelPrice.java
@@ -40,7 +40,14 @@ public class IslandLevelPrice extends Price {
 
     @Override
     public String getPublicDescription(User user) {
-        return user.getTranslation("upgrades.prices.islandlevel.description");
+        return user.getTranslation("upgrades.prices.islandlevel.description", "[level]", "?");
+    }
+
+    @Override
+    public String getPublicDescription(User user, PriceDB priceDB) {
+        IslandLevelPriceDB db = (IslandLevelPriceDB) priceDB;
+        return user.getTranslation("upgrades.prices.islandlevel.description",
+                "[level]", db.getLevelNeededEquation());
     }
 
     @Override

--- a/src/main/java/world/bentobox/upgrades/dataobjects/prices/ItemPrice.java
+++ b/src/main/java/world/bentobox/upgrades/dataobjects/prices/ItemPrice.java
@@ -35,7 +35,15 @@ public class ItemPrice extends Price {
 
     @Override
     public String getPublicDescription(User user) {
-        return user.getTranslation("upgrades.prices.item.description");
+        return user.getTranslation("upgrades.prices.item.description", "[amount]", "?", "[item]", "?");
+    }
+
+    @Override
+    public String getPublicDescription(User user, PriceDB priceDB) {
+        ItemPriceDB db = (ItemPriceDB) priceDB;
+        return user.getTranslation("upgrades.prices.item.description",
+                "[amount]", Integer.toString(db.getAmount()),
+                "[item]", db.getMaterial());
     }
 
     @Override

--- a/src/main/java/world/bentobox/upgrades/dataobjects/prices/PermissionPrice.java
+++ b/src/main/java/world/bentobox/upgrades/dataobjects/prices/PermissionPrice.java
@@ -34,7 +34,14 @@ public class PermissionPrice extends Price {
 
     @Override
     public String getPublicDescription(User user) {
-        return user.getTranslation("upgrades.prices.permission.description");
+        return user.getTranslation("upgrades.prices.permission.description", "[permission]", "?");
+    }
+
+    @Override
+    public String getPublicDescription(User user, PriceDB priceDB) {
+        PermissionPriceDB db = (PermissionPriceDB) priceDB;
+        return user.getTranslation("upgrades.prices.permission.description",
+                "[permission]", db.getPermission());
     }
 
     @Override

--- a/src/main/java/world/bentobox/upgrades/dataobjects/rewards/LimitsReward.java
+++ b/src/main/java/world/bentobox/upgrades/dataobjects/rewards/LimitsReward.java
@@ -45,7 +45,17 @@ public class LimitsReward extends Reward {
 
     @Override
     public String getPublicDescription(User user) {
-        return user.getTranslation("upgrades.rewards.limits.description");
+        return user.getTranslation("upgrades.rewards.limits.description",
+                "[type]", "?", "[target]", "?", "[amount]", "?");
+    }
+
+    @Override
+    public String getPublicDescription(User user, RewardDB rewardDB) {
+        LimitsRewardDB db = (LimitsRewardDB) rewardDB;
+        return user.getTranslation("upgrades.rewards.limits.description",
+                "[type]", db.getLimitType(),
+                "[target]", db.getTarget(),
+                "[amount]", db.getAmountEquation());
     }
 
     @Override

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -134,9 +134,7 @@ upgrades:
   prices:
     islandlevel:
       name: "Island level"
-      description: |-
-        Required island level
-        Don't consume anything
+      description: "Min. island level: [level]"
       admindescription: |-
         Add a minimum required level
         This price don't use anything


### PR DESCRIPTION
## Summary

- Seeds 6 example upgrades automatically for any game mode that has no upgrades configured yet (first install). Once created they are fully editable/deletable via the admin GUI.
- Adds `DefaultUpgradeSeeder` class with one method `seedIfEmpty()` called from `onEnable()`.
- Adds `getPublicDescription(User, PriceDB/RewardDB)` overloads to `IslandLevelPrice`, `ItemPrice`, `PermissionPrice`, and `LimitsReward` so placeholder values (`[level]`, `[amount]`, `[item]`, `[permission]`, `[type]`, `[target]`) are substituted with actual configured values in the player shop panel.

### Example upgrades seeded

| # | Name | Price | Reward | Purchases |
|---|------|-------|--------|-----------|
| 1 | Border Expansion I | $500 | +5 border blocks | 5× |
| 2 | Border Expansion II | Island level 100 + $2000 | +10 border blocks | 3× |
| 3 | Hopper Limit | $1000 | +2 hopper block limit | 5× |
| 4 | Cow Limit | $500 | +2 cow entity limit | 5× |
| 5 | Diamond Border | 10 diamonds | +3 border blocks | 3× |
| 6 | Donor Perk | `upgrades.example.donor` permission | Console command | 1× |

## Test plan
- [ ] Fresh server install: log shows "Seeded 6 example upgrades for BSkyBlock"
- [ ] Player runs `/bsb upgrade` — all 6 examples appear with correct descriptions (amounts/types substituted, not literal placeholders)
- [ ] Server with existing upgrades: no seeding occurs on reload
- [ ] Admin edits/deletes an example via admin GUI — works normally
- [ ] `mvn test` passes (102 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)