### PR TITLE
Add spawner boost and crop growth boost reward types

### DIFF
--- a/src/main/java/world/bentobox/upgrades/DefaultUpgradeSeeder.java
+++ b/src/main/java/world/bentobox/upgrades/DefaultUpgradeSeeder.java
@@ -10,8 +10,10 @@ import world.bentobox.upgrades.dataobjects.prices.ItemPriceDB;
 import world.bentobox.upgrades.dataobjects.prices.MoneyPriceDB;
 import world.bentobox.upgrades.dataobjects.prices.PermissionPriceDB;
 import world.bentobox.upgrades.dataobjects.rewards.CommandRewardDB;
+import world.bentobox.upgrades.dataobjects.rewards.CropGrowthRewardDB;
 import world.bentobox.upgrades.dataobjects.rewards.LimitsRewardDB;
 import world.bentobox.upgrades.dataobjects.rewards.RangeRewardDB;
+import world.bentobox.upgrades.dataobjects.rewards.SpawnerRewardDB;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -36,7 +38,7 @@ public class DefaultUpgradeSeeder {
         for (String gm : addon.getHookedGameModes()) {
             if (dm.getUpgradeDataByGameMode(gm).isEmpty()) {
                 seed(dm, gm);
-                addon.log("Seeded 6 example upgrades for " + gm
+                addon.log("Seeded 8 example upgrades for " + gm
                         + " — edit or delete them via /[gamemode] admin upgrade");
             }
         }
@@ -49,6 +51,8 @@ public class DefaultUpgradeSeeder {
         seedCowLimit(dm, gm);
         seedDiamondBorder(dm, gm);
         seedDonorPerk(dm, gm);
+        seedSpawnerBoost(dm, gm);
+        seedCropBoost(dm, gm);
     }
 
     // ─── Example 1: Border Expansion I ───────────────────────────────────────
@@ -219,6 +223,60 @@ public class DefaultUpgradeSeeder {
         cmd.setCommands(commands);
         cmd.setConsole(true);
         tier.setRewards(List.of(cmd));
+
+        dm.saveUpgradeTier(tier);
+    }
+
+    // ─── Example 7: Spawner Boost ─────────────────────────────────────────────
+    // Demonstrates: MoneyPrice → SpawnerRewardDB (5 purchases)
+
+    private void seedSpawnerBoost(UpgradesDataManager dm, String gm) {
+        UpgradeData data = dm.createUpgradeData(gm + "_example_spawner", gm, null);
+        if (data == null) return;
+        data.setName("Spawner Boost");
+        data.setIcon(new ItemStack(Material.SPAWNER));
+        data.setOrder(7);
+        data.setDescription(List.of("Example: pay $2000 for +0.5 extra entities per spawner trigger."));
+        dm.saveUpgradeData(data);
+
+        UpgradeTier tier = dm.createUpgradeTier(gm + "_example_spawner_t1", data, 0, 4, null);
+        if (tier == null) return;
+        tier.setName("Spawner Boost");
+
+        MoneyPriceDB money = new MoneyPriceDB();
+        money.setAmountEquation("2000");
+        tier.setPrices(List.of(money));
+
+        SpawnerRewardDB spawner = new SpawnerRewardDB();
+        spawner.setSpawnBonusEquation("0.5");
+        tier.setRewards(List.of(spawner));
+
+        dm.saveUpgradeTier(tier);
+    }
+
+    // ─── Example 8: Crop Growth Boost ─────────────────────────────────────────
+    // Demonstrates: MoneyPrice → CropGrowthRewardDB (5 purchases)
+
+    private void seedCropBoost(UpgradesDataManager dm, String gm) {
+        UpgradeData data = dm.createUpgradeData(gm + "_example_cropgrowth", gm, null);
+        if (data == null) return;
+        data.setName("Crop Growth Boost");
+        data.setIcon(new ItemStack(Material.WHEAT));
+        data.setOrder(8);
+        data.setDescription(List.of("Example: pay $500 for 50% extra growth chance per crop tick."));
+        dm.saveUpgradeData(data);
+
+        UpgradeTier tier = dm.createUpgradeTier(gm + "_example_cropgrowth_t1", data, 0, 4, null);
+        if (tier == null) return;
+        tier.setName("Crop Growth Boost");
+
+        MoneyPriceDB money = new MoneyPriceDB();
+        money.setAmountEquation("500");
+        tier.setPrices(List.of(money));
+
+        CropGrowthRewardDB crop = new CropGrowthRewardDB();
+        crop.setGrowthBonusEquation("0.5");
+        tier.setRewards(List.of(crop));
 
         dm.saveUpgradeTier(tier);
     }

--- a/src/main/java/world/bentobox/upgrades/UpgradesAddon.java
+++ b/src/main/java/world/bentobox/upgrades/UpgradesAddon.java
@@ -31,12 +31,16 @@ import world.bentobox.upgrades.dataobjects.prices.ItemPrice;
 import world.bentobox.upgrades.dataobjects.prices.MoneyPrice;
 import world.bentobox.upgrades.dataobjects.prices.PermissionPrice;
 import world.bentobox.upgrades.dataobjects.rewards.CommandReward;
+import world.bentobox.upgrades.dataobjects.rewards.CropGrowthReward;
 import world.bentobox.upgrades.dataobjects.rewards.LimitsReward;
 import world.bentobox.upgrades.dataobjects.rewards.RangeReward;
+import world.bentobox.upgrades.dataobjects.rewards.SpawnerReward;
 import world.bentobox.upgrades.DefaultUpgradeSeeder;
 import world.bentobox.upgrades.upgrades.DatabaseUpgrade;
+import world.bentobox.upgrades.listeners.CropGrowthListener;
 import world.bentobox.upgrades.listeners.IslandChangeListener;
 import world.bentobox.upgrades.listeners.JoinPermCheckListener;
+import world.bentobox.upgrades.listeners.SpawnerUpgradeListener;
 import world.bentobox.upgrades.ui.utils.ChatInput;
 
 public class UpgradesAddon extends Addon {
@@ -110,6 +114,8 @@ public class UpgradesAddon extends Addon {
             this.upgradesManager.addReward(new RangeReward());
             this.upgradesManager.addReward(new LimitsReward());
             this.upgradesManager.addReward(new CommandReward());
+            this.upgradesManager.addReward(new SpawnerReward());
+            this.upgradesManager.addReward(new CropGrowthReward());
 
             // Seed example upgrades for any game mode that has none yet
             new DefaultUpgradeSeeder(this).seedIfEmpty();
@@ -122,6 +128,8 @@ public class UpgradesAddon extends Addon {
             );
 
             this.registerListener(new IslandChangeListener(this));
+            this.registerListener(new SpawnerUpgradeListener(this));
+            this.registerListener(new CropGrowthListener(this));
 
             if (this.isLimitsProvided())
                 this.registerListener(new JoinPermCheckListener(this));

--- a/src/main/java/world/bentobox/upgrades/dataobjects/rewards/CropGrowthReward.java
+++ b/src/main/java/world/bentobox/upgrades/dataobjects/rewards/CropGrowthReward.java
@@ -1,0 +1,159 @@
+package world.bentobox.upgrades.dataobjects.rewards;
+
+import org.bukkit.Material;
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
+import world.bentobox.bentobox.api.addons.GameModeAddon;
+import world.bentobox.bentobox.api.panels.PanelItem;
+import world.bentobox.bentobox.api.panels.builders.PanelItemBuilder;
+import world.bentobox.bentobox.api.user.User;
+import world.bentobox.bentobox.database.objects.Island;
+import world.bentobox.upgrades.UpgradesAddon;
+import world.bentobox.upgrades.config.Settings;
+import world.bentobox.upgrades.dataobjects.UpgradeTier;
+import world.bentobox.upgrades.ui.utils.AbPanel;
+
+import java.security.InvalidParameterException;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.function.Consumer;
+
+public class CropGrowthReward extends Reward {
+
+    public CropGrowthReward() {
+        super("crop_growth_reward", Material.WHEAT);
+    }
+
+    @Override
+    public String getAdminName(User user) {
+        return user.getTranslation("upgrades.rewards.cropgrowth.name");
+    }
+
+    @Override
+    public String getAdminDescription(User user) {
+        return user.getTranslation("upgrades.rewards.cropgrowth.admindescription");
+    }
+
+    @Override
+    public String getPublicName(User user) {
+        return user.getTranslation("upgrades.rewards.cropgrowth.name");
+    }
+
+    @Override
+    public String getPublicDescription(User user) {
+        return user.getTranslation("upgrades.rewards.cropgrowth.description");
+    }
+
+    @Override
+    public String getPublicDescription(User user, RewardDB rewardDB) {
+        CropGrowthRewardDB db = (CropGrowthRewardDB) rewardDB;
+        return user.getTranslation("upgrades.rewards.cropgrowth.description",
+                "[amount]", db.getGrowthBonusEquation());
+    }
+
+    @Override
+    public void apply(UpgradesAddon addon, User user, Island island, RewardDB rewardDB) {
+        // No-op: ongoing effect handled by CropGrowthListener
+    }
+
+    @Override
+    public AbPanel getAdminPanel(UpgradesAddon addon, GameModeAddon gamemode, User user, AbPanel parent,
+                                 UpgradeTier tier, @Nullable RewardDB saved) {
+        CropGrowthRewardDB dbObject;
+
+        if (saved == null) {
+            dbObject = new CropGrowthRewardDB();
+            List<RewardDB> rewards = tier.getRewards();
+            rewards.add(dbObject);
+            tier.setRewards(rewards);
+        } else if (saved instanceof CropGrowthRewardDB) {
+            dbObject = (CropGrowthRewardDB) saved;
+        } else {
+            throw new InvalidParameterException(
+                    "DB object in CropGrowthReward which is not a CropGrowthRewardDB");
+        }
+
+        return new CropGrowthRewardPanel(addon, gamemode, user, parent, tier, dbObject);
+    }
+
+    private final class CropGrowthRewardPanel extends AbPanel {
+        private static final String VALID = "valid";
+        private static final String INVALID = "invalid";
+        private static final String RULE = "rule";
+
+        private final UpgradeTier tier;
+        private final CropGrowthRewardDB saved;
+
+        public CropGrowthRewardPanel(UpgradesAddon addon, GameModeAddon gamemode,
+                                     User user, AbPanel parent,
+                                     @NonNull UpgradeTier tier,
+                                     @NonNull CropGrowthRewardDB saved) {
+            super(addon, gamemode, user, user.getTranslation("upgrades.rewards.cropgrowth.paneltitle"),
+                    parent);
+
+            this.tier = tier;
+            this.saved = saved;
+
+            this.createInterface();
+        }
+
+        private void createInterface() {
+            this.fillBorder(Material.BLACK_STAINED_GLASS_PANE);
+
+            if (this.saved.isValid()) {
+                this.setItems(VALID, new PanelItemBuilder()
+                        .name(this.getUser().getTranslation("upgrades.rewards.cropgrowth.formulastatus"))
+                        .description(this.saved.getGrowthBonusEquation())
+                        .icon(Material.GREEN_CONCRETE)
+                        .build(), 10);
+            } else {
+                this.setItems(INVALID, new PanelItemBuilder()
+                        .name(this.getUser().getTranslation("upgrades.rewards.cropgrowth.formulaneeded"))
+                        .description(this.getUser().getTranslation("upgrades.rewards.cropgrowth.formulaneededdesc"))
+                        .icon(Material.RED_CONCRETE)
+                        .build(), 10);
+            }
+
+            this.setItems(RULE, new PanelItemBuilder()
+                    .name(this.getUser().getTranslation("upgrades.rewards.cropgrowth.setformula"))
+                    .description(this.saved.getGrowthBonusEquation())
+                    .icon(Material.PAPER)
+                    .clickHandler(this.onSetRule())
+                    .build(), 22);
+        }
+
+        private PanelItem.ClickHandler onSetRule() {
+            return (panel, client, click, slot) -> {
+                this.getAddon()
+                        .getChatInput()
+                        .askOneInput(this.doSetRule(),
+                                input -> {
+                                    try {
+                                        Map<String, Double> vars = new TreeMap<>();
+                                        vars.put("[level]", 1.0);
+                                        vars.put("[islandLevel]", 1.0);
+                                        vars.put("[numberPlayer]", 1.0);
+                                        Settings.evaluate(input, vars);
+                                        return true;
+                                    } catch (Exception e) {
+                                        return false;
+                                    }
+                                },
+                                client.getTranslation("upgrades.rewards.cropgrowth.rulequestion",
+                                        "[actual]", this.saved.getGrowthBonusEquation()),
+                                client.getTranslation("upgrades.rewards.cropgrowth.invalidrule"),
+                                client, false);
+                return true;
+            };
+        }
+
+        private Consumer<String> doSetRule() {
+            return (rule) -> {
+                this.saved.setGrowthBonusEquation(rule);
+                this.createInterface();
+                this.getBuild().build();
+            };
+        }
+    }
+}

--- a/src/main/java/world/bentobox/upgrades/dataobjects/rewards/CropGrowthRewardDB.java
+++ b/src/main/java/world/bentobox/upgrades/dataobjects/rewards/CropGrowthRewardDB.java
@@ -1,0 +1,28 @@
+package world.bentobox.upgrades.dataobjects.rewards;
+
+import com.google.gson.annotations.Expose;
+
+public class CropGrowthRewardDB extends RewardDB {
+
+    @Expose
+    private String growthBonusEquation = "0";
+
+    public String getGrowthBonusEquation() {
+        return growthBonusEquation;
+    }
+
+    public void setGrowthBonusEquation(String growthBonusEquation) {
+        this.growthBonusEquation = growthBonusEquation;
+    }
+
+    @Override
+    public boolean isValid() {
+        return growthBonusEquation != null && !growthBonusEquation.isEmpty();
+    }
+
+    @Override
+    public Class<CropGrowthReward> getRewardType() {
+        return CropGrowthReward.class;
+    }
+
+}

--- a/src/main/java/world/bentobox/upgrades/dataobjects/rewards/SpawnerReward.java
+++ b/src/main/java/world/bentobox/upgrades/dataobjects/rewards/SpawnerReward.java
@@ -1,0 +1,159 @@
+package world.bentobox.upgrades.dataobjects.rewards;
+
+import org.bukkit.Material;
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
+import world.bentobox.bentobox.api.addons.GameModeAddon;
+import world.bentobox.bentobox.api.panels.PanelItem;
+import world.bentobox.bentobox.api.panels.builders.PanelItemBuilder;
+import world.bentobox.bentobox.api.user.User;
+import world.bentobox.bentobox.database.objects.Island;
+import world.bentobox.upgrades.UpgradesAddon;
+import world.bentobox.upgrades.config.Settings;
+import world.bentobox.upgrades.dataobjects.UpgradeTier;
+import world.bentobox.upgrades.ui.utils.AbPanel;
+
+import java.security.InvalidParameterException;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.function.Consumer;
+
+public class SpawnerReward extends Reward {
+
+    public SpawnerReward() {
+        super("spawner_reward", Material.SPAWNER);
+    }
+
+    @Override
+    public String getAdminName(User user) {
+        return user.getTranslation("upgrades.rewards.spawner.name");
+    }
+
+    @Override
+    public String getAdminDescription(User user) {
+        return user.getTranslation("upgrades.rewards.spawner.admindescription");
+    }
+
+    @Override
+    public String getPublicName(User user) {
+        return user.getTranslation("upgrades.rewards.spawner.name");
+    }
+
+    @Override
+    public String getPublicDescription(User user) {
+        return user.getTranslation("upgrades.rewards.spawner.description");
+    }
+
+    @Override
+    public String getPublicDescription(User user, RewardDB rewardDB) {
+        SpawnerRewardDB db = (SpawnerRewardDB) rewardDB;
+        return user.getTranslation("upgrades.rewards.spawner.description",
+                "[amount]", db.getSpawnBonusEquation());
+    }
+
+    @Override
+    public void apply(UpgradesAddon addon, User user, Island island, RewardDB rewardDB) {
+        // No-op: ongoing effect handled by SpawnerUpgradeListener
+    }
+
+    @Override
+    public AbPanel getAdminPanel(UpgradesAddon addon, GameModeAddon gamemode, User user, AbPanel parent,
+                                 UpgradeTier tier, @Nullable RewardDB saved) {
+        SpawnerRewardDB dbObject;
+
+        if (saved == null) {
+            dbObject = new SpawnerRewardDB();
+            List<RewardDB> rewards = tier.getRewards();
+            rewards.add(dbObject);
+            tier.setRewards(rewards);
+        } else if (saved instanceof SpawnerRewardDB) {
+            dbObject = (SpawnerRewardDB) saved;
+        } else {
+            throw new InvalidParameterException(
+                    "DB object in SpawnerReward which is not a SpawnerRewardDB");
+        }
+
+        return new SpawnerRewardPanel(addon, gamemode, user, parent, tier, dbObject);
+    }
+
+    private final class SpawnerRewardPanel extends AbPanel {
+        private static final String VALID = "valid";
+        private static final String INVALID = "invalid";
+        private static final String RULE = "rule";
+
+        private final UpgradeTier tier;
+        private final SpawnerRewardDB saved;
+
+        public SpawnerRewardPanel(UpgradesAddon addon, GameModeAddon gamemode,
+                                  User user, AbPanel parent,
+                                  @NonNull UpgradeTier tier,
+                                  @NonNull SpawnerRewardDB saved) {
+            super(addon, gamemode, user, user.getTranslation("upgrades.rewards.spawner.paneltitle"),
+                    parent);
+
+            this.tier = tier;
+            this.saved = saved;
+
+            this.createInterface();
+        }
+
+        private void createInterface() {
+            this.fillBorder(Material.BLACK_STAINED_GLASS_PANE);
+
+            if (this.saved.isValid()) {
+                this.setItems(VALID, new PanelItemBuilder()
+                        .name(this.getUser().getTranslation("upgrades.rewards.spawner.formulastatus"))
+                        .description(this.saved.getSpawnBonusEquation())
+                        .icon(Material.GREEN_CONCRETE)
+                        .build(), 10);
+            } else {
+                this.setItems(INVALID, new PanelItemBuilder()
+                        .name(this.getUser().getTranslation("upgrades.rewards.spawner.formulaneeded"))
+                        .description(this.getUser().getTranslation("upgrades.rewards.spawner.formulaneededdesc"))
+                        .icon(Material.RED_CONCRETE)
+                        .build(), 10);
+            }
+
+            this.setItems(RULE, new PanelItemBuilder()
+                    .name(this.getUser().getTranslation("upgrades.rewards.spawner.setformula"))
+                    .description(this.saved.getSpawnBonusEquation())
+                    .icon(Material.PAPER)
+                    .clickHandler(this.onSetRule())
+                    .build(), 22);
+        }
+
+        private PanelItem.ClickHandler onSetRule() {
+            return (panel, client, click, slot) -> {
+                this.getAddon()
+                        .getChatInput()
+                        .askOneInput(this.doSetRule(),
+                                input -> {
+                                    try {
+                                        Map<String, Double> vars = new TreeMap<>();
+                                        vars.put("[level]", 1.0);
+                                        vars.put("[islandLevel]", 1.0);
+                                        vars.put("[numberPlayer]", 1.0);
+                                        Settings.evaluate(input, vars);
+                                        return true;
+                                    } catch (Exception e) {
+                                        return false;
+                                    }
+                                },
+                                client.getTranslation("upgrades.rewards.spawner.rulequestion",
+                                        "[actual]", this.saved.getSpawnBonusEquation()),
+                                client.getTranslation("upgrades.rewards.spawner.invalidrule"),
+                                client, false);
+                return true;
+            };
+        }
+
+        private Consumer<String> doSetRule() {
+            return (rule) -> {
+                this.saved.setSpawnBonusEquation(rule);
+                this.createInterface();
+                this.getBuild().build();
+            };
+        }
+    }
+}

--- a/src/main/java/world/bentobox/upgrades/dataobjects/rewards/SpawnerRewardDB.java
+++ b/src/main/java/world/bentobox/upgrades/dataobjects/rewards/SpawnerRewardDB.java
@@ -1,0 +1,28 @@
+package world.bentobox.upgrades.dataobjects.rewards;
+
+import com.google.gson.annotations.Expose;
+
+public class SpawnerRewardDB extends RewardDB {
+
+    @Expose
+    private String spawnBonusEquation = "0";
+
+    public String getSpawnBonusEquation() {
+        return spawnBonusEquation;
+    }
+
+    public void setSpawnBonusEquation(String spawnBonusEquation) {
+        this.spawnBonusEquation = spawnBonusEquation;
+    }
+
+    @Override
+    public boolean isValid() {
+        return spawnBonusEquation != null && !spawnBonusEquation.isEmpty();
+    }
+
+    @Override
+    public Class<SpawnerReward> getRewardType() {
+        return SpawnerReward.class;
+    }
+
+}

--- a/src/main/java/world/bentobox/upgrades/listeners/CropGrowthListener.java
+++ b/src/main/java/world/bentobox/upgrades/listeners/CropGrowthListener.java
@@ -1,0 +1,107 @@
+package world.bentobox.upgrades.listeners;
+
+import org.bukkit.Bukkit;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockGrowEvent;
+
+import world.bentobox.bentobox.database.objects.Island;
+import world.bentobox.upgrades.UpgradesAddon;
+import world.bentobox.upgrades.api.UpgradeAPI;
+import world.bentobox.upgrades.config.Settings;
+import world.bentobox.upgrades.dataobjects.UpgradeTier;
+import world.bentobox.upgrades.dataobjects.UpgradesData;
+import world.bentobox.upgrades.dataobjects.rewards.CropGrowthRewardDB;
+import world.bentobox.upgrades.dataobjects.rewards.RewardDB;
+import world.bentobox.upgrades.upgrades.DatabaseUpgrade;
+
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+public class CropGrowthListener implements Listener {
+
+    private final UpgradesAddon addon;
+
+    public CropGrowthListener(UpgradesAddon addon) {
+        this.addon = addon;
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onBlockGrow(BlockGrowEvent event) {
+        Block block = event.getBlock();
+        if (!isCrop(block)) return;
+
+        Island island = addon.getPlugin().getIslands()
+                .getIslandAt(block.getLocation()).orElse(null);
+        if (island == null) return;
+
+        double bonus = computeBonus(island);
+        if (bonus <= 0) return;
+
+        int guaranteed = (int) bonus;
+        double chance = bonus - guaranteed;
+        int extra = guaranteed + (Math.random() < chance ? 1 : 0);
+        if (extra <= 0) return;
+
+        Bukkit.getScheduler().runTask(addon.getPlugin(), () -> {
+            for (int i = 0; i < extra; i++) {
+                block.applyBoneMeal(BlockFace.UP);
+            }
+        });
+    }
+
+    private boolean isCrop(Block block) {
+        return switch (block.getType()) {
+            case WHEAT, CARROTS, POTATOES, BEETROOTS, NETHER_WART,
+                 SWEET_BERRY_BUSH, TORCHFLOWER_CROP, PITCHER_CROP -> true;
+            default -> false;
+        };
+    }
+
+    private double computeBonus(Island island) {
+        double total = 0.0;
+        long islandLevel = addon.getUpgradesManager().getIslandLevel(island);
+        int memberCount = island.getMemberSet().size();
+
+        for (UpgradeAPI upgradeAPI : addon.getAvailableUpgrades()) {
+            if (!(upgradeAPI instanceof DatabaseUpgrade)) continue;
+            DatabaseUpgrade dbUpgrade = (DatabaseUpgrade) upgradeAPI;
+
+            UpgradesData data = addon.getUpgradesLevels(island.getUniqueId());
+            int currentLevel = data.getUpgradeLevel(dbUpgrade.getName());
+            if (currentLevel <= 0) continue;
+
+            // Find the most recently purchased tier (startLevel <= currentLevel-1 <= endLevel)
+            List<UpgradeTier> tiers = addon.getUpgradeDataManager()
+                    .getUpgradeTierByUpgradeData(dbUpgrade.getUpgradeData());
+            UpgradeTier activeTier = null;
+            for (UpgradeTier tier : tiers) {
+                if (tier.getStartLevel() <= currentLevel - 1 && currentLevel - 1 <= tier.getEndLevel()) {
+                    activeTier = tier;
+                    break;
+                }
+            }
+            if (activeTier == null) continue;
+
+            for (RewardDB rewardDB : activeTier.getRewards()) {
+                if (!(rewardDB instanceof CropGrowthRewardDB)) continue;
+                CropGrowthRewardDB cropDB = (CropGrowthRewardDB) rewardDB;
+
+                Map<String, Double> vars = new TreeMap<>();
+                vars.put("[level]", (double) currentLevel);
+                vars.put("[islandLevel]", (double) islandLevel);
+                vars.put("[numberPlayer]", (double) memberCount);
+                try {
+                    total += Settings.evaluate(cropDB.getGrowthBonusEquation(), vars);
+                } catch (Exception ignored) {
+                    // Malformed formula — skip
+                }
+            }
+        }
+        return total;
+    }
+}

--- a/src/main/java/world/bentobox/upgrades/listeners/SpawnerUpgradeListener.java
+++ b/src/main/java/world/bentobox/upgrades/listeners/SpawnerUpgradeListener.java
@@ -1,0 +1,99 @@
+package world.bentobox.upgrades.listeners;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.entity.EntityType;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.SpawnerSpawnEvent;
+
+import world.bentobox.bentobox.database.objects.Island;
+import world.bentobox.upgrades.UpgradesAddon;
+import world.bentobox.upgrades.api.UpgradeAPI;
+import world.bentobox.upgrades.config.Settings;
+import world.bentobox.upgrades.dataobjects.UpgradeTier;
+import world.bentobox.upgrades.dataobjects.UpgradesData;
+import world.bentobox.upgrades.dataobjects.rewards.RewardDB;
+import world.bentobox.upgrades.dataobjects.rewards.SpawnerRewardDB;
+import world.bentobox.upgrades.upgrades.DatabaseUpgrade;
+
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+public class SpawnerUpgradeListener implements Listener {
+
+    private final UpgradesAddon addon;
+
+    public SpawnerUpgradeListener(UpgradesAddon addon) {
+        this.addon = addon;
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onSpawnerSpawn(SpawnerSpawnEvent event) {
+        Island island = addon.getPlugin().getIslands()
+                .getIslandAt(event.getLocation()).orElse(null);
+        if (island == null) return;
+
+        double bonus = computeBonus(island);
+        if (bonus <= 0) return;
+
+        int guaranteed = (int) bonus;
+        double chance = bonus - guaranteed;
+        int extra = guaranteed + (Math.random() < chance ? 1 : 0);
+        if (extra <= 0) return;
+
+        EntityType type = event.getEntityType();
+        Location loc = event.getLocation();
+        // Schedule 1 tick later to avoid SpawnerSpawnEvent recursion
+        Bukkit.getScheduler().runTask(addon.getPlugin(), () -> {
+            for (int i = 0; i < extra; i++) {
+                loc.getWorld().spawnEntity(loc, type);
+            }
+        });
+    }
+
+    private double computeBonus(Island island) {
+        double total = 0.0;
+        long islandLevel = addon.getUpgradesManager().getIslandLevel(island);
+        int memberCount = island.getMemberSet().size();
+
+        for (UpgradeAPI upgradeAPI : addon.getAvailableUpgrades()) {
+            if (!(upgradeAPI instanceof DatabaseUpgrade)) continue;
+            DatabaseUpgrade dbUpgrade = (DatabaseUpgrade) upgradeAPI;
+
+            UpgradesData data = addon.getUpgradesLevels(island.getUniqueId());
+            int currentLevel = data.getUpgradeLevel(dbUpgrade.getName());
+            if (currentLevel <= 0) continue;
+
+            // Find the most recently purchased tier (startLevel <= currentLevel-1 <= endLevel)
+            List<UpgradeTier> tiers = addon.getUpgradeDataManager()
+                    .getUpgradeTierByUpgradeData(dbUpgrade.getUpgradeData());
+            UpgradeTier activeTier = null;
+            for (UpgradeTier tier : tiers) {
+                if (tier.getStartLevel() <= currentLevel - 1 && currentLevel - 1 <= tier.getEndLevel()) {
+                    activeTier = tier;
+                    break;
+                }
+            }
+            if (activeTier == null) continue;
+
+            for (RewardDB rewardDB : activeTier.getRewards()) {
+                if (!(rewardDB instanceof SpawnerRewardDB)) continue;
+                SpawnerRewardDB spawnerDB = (SpawnerRewardDB) rewardDB;
+
+                Map<String, Double> vars = new TreeMap<>();
+                vars.put("[level]", (double) currentLevel);
+                vars.put("[islandLevel]", (double) islandLevel);
+                vars.put("[numberPlayer]", (double) memberCount);
+                try {
+                    total += Settings.evaluate(spawnerDB.getSpawnBonusEquation(), vars);
+                } catch (Exception ignored) {
+                    // Malformed formula — skip
+                }
+            }
+        }
+        return total;
+    }
+}

--- a/src/main/java/world/bentobox/upgrades/ui/admin/EditTierPanel.java
+++ b/src/main/java/world/bentobox/upgrades/ui/admin/EditTierPanel.java
@@ -301,14 +301,14 @@ public final class EditTierPanel extends AbPanel {
                 if (delete) {
                     List<PriceDB> prices = this.tier.getPrices();
                     prices = prices.stream()
-                            .filter(p -> p.getPriceType() == price.getClass())
+                            .filter(p -> p.getPriceType() != price.getClass())
                             .collect(
                                     Collectors.toList());
                     this.tier.setPrices(prices);
                 }
                 this.getBuild()
                         .build();
-            });
+            }).getBuild().build();
 
     private final Consumer<Reward> onDeleteReward = (reward) ->
             new YesNoPanel(this.getAddon(), this.getGamemode(), this.getUser(), this.getUser()
@@ -316,14 +316,14 @@ public final class EditTierPanel extends AbPanel {
                 if (delete) {
                     List<RewardDB> rewards = this.tier.getRewards();
                     rewards = rewards.stream()
-                            .filter(r -> r.getRewardType() == reward.getClass())
+                            .filter(r -> r.getRewardType() != reward.getClass())
                             .collect(
                                     Collectors.toList());
                     this.tier.setRewards(rewards);
                 }
                 this.getBuild()
                         .build();
-            });
+            }).getBuild().build();
 
     private final Runnable onCreatePrice = () -> {
         String title = this.getUser()

--- a/src/main/java/world/bentobox/upgrades/upgrades/DatabaseUpgrade.java
+++ b/src/main/java/world/bentobox/upgrades/upgrades/DatabaseUpgrade.java
@@ -125,6 +125,10 @@ public class DatabaseUpgrade extends UpgradeAPI {
                 .equals(upgradeData.getWorld());
     }
 
+    public UpgradeData getUpgradeData() {
+        return upgradeData;
+    }
+
     /**
      * Find the tier that covers the current level (i.e. the next purchase available).
      * Level 0 = not yet purchased; a tier with startLevel=0, endLevel=0 means one purchase.

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -189,6 +189,32 @@ upgrades:
       description: "Runs commands on upgrade"
       admindescription: "Execute console or player commands"
       paneltitle: "Command reward"
+    spawner:
+      name: "Spawner Boost"
+      description: "+[amount] entities per spawner trigger"
+      admindescription: "Spawn extra entities per spawner activation"
+      paneltitle: "Spawner boost reward"
+      rulequestion: |-
+        Enter spawn bonus formula (e.g. 0.5, 0.1*[level])
+        Actual: [actual]
+      invalidrule: "Invalid formula. Use a number or math expression (e.g. 0.5, 0.1*[level])"
+      setformula: "Set spawn bonus formula"
+      formulastatus: "Formula OK"
+      formulaneeded: "Formula needed"
+      formulaneededdesc: "Click the paper icon to set a spawn bonus formula"
+    cropgrowth:
+      name: "Crop Growth Boost"
+      description: "+[amount] extra growth trigger per crop tick"
+      admindescription: "Increase crop growth speed per island"
+      paneltitle: "Crop growth reward"
+      rulequestion: |-
+        Enter growth bonus formula (e.g. 0.5, 0.1*[level])
+        Actual: [actual]
+      invalidrule: "Invalid formula. Use a number or math expression (e.g. 0.5, 0.1*[level])"
+      setformula: "Set growth bonus formula"
+      formulastatus: "Formula OK"
+      formulaneeded: "Formula needed"
+      formulaneededdesc: "Click the paper icon to set a growth bonus formula"
 protection:
   flags:
     UPGRADES_RANK_RIGHT:


### PR DESCRIPTION
## Summary

- Adds two new reward types: **SpawnerReward** (boosts mob spawner rates) and **CropGrowthReward** (boosts crop growth speed) with corresponding DB objects and listeners
- Seeds example upgrades for both new reward types in `DefaultUpgradeSeeder`
- Fixes right-click delete for prices and rewards in the admin tier editor (`EditTierPanel`): `YesNoPanel` was never shown (missing `.getBuild().build()` call), and the filter predicate was inverted (`==` instead of `!=`), causing the wrong items to be removed

## Test plan

- [ ] Build passes: `mvn clean package`
- [ ] All 102 tests pass: `mvn test`
- [ ] In-game: spawner upgrade boosts spawner rate on islands that have the reward applied
- [ ] In-game: crop growth upgrade boosts crop growth on islands that have the reward applied
- [ ] In-game: right-click a price/reward in the tier editor → YesNoPanel confirmation appears → clicking Yes removes only that item

🤖 Generated with [Claude Code](https://claude.com/claude-code)