### PR TITLE
Convert player upgrade panel to BentoBox TemplatedPanel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Upgrades is a BentoBox addon (Paper/Bukkit plugin) that lets island players purchase upgrades using Vault economy. It hooks into BentoBox GameMode addons (BSkyBlock, AcidIsland, CaveBlock, SkyGrid, AOneBlock) and optionally integrates with the Level and Limits addons.
 
+### Relation to other addons for BentoBox
+
+Upgrades runs within the BentoBox system as a plugin/addon to it. For coding, testing, and other patterns, it can and should draw on what other addons and BentoBox itself does. So the wider code base should be utilized when needed. This can be found at https://bentobox.world (GitHub) and the CI system is in https://ci.bentobox.world (CodeMC).
+
 ## Build & Test Commands
 
 ```bash

--- a/src/main/java/world/bentobox/upgrades/UpgradesAddon.java
+++ b/src/main/java/world/bentobox/upgrades/UpgradesAddon.java
@@ -117,6 +117,8 @@ public class UpgradesAddon extends Addon {
             this.upgradesManager.addReward(new SpawnerReward());
             this.upgradesManager.addReward(new CropGrowthReward());
 
+            saveResource("panels/upgrades_panel.yml", false);
+
             // Seed example upgrades for any game mode that has none yet
             new DefaultUpgradeSeeder(this).seedIfEmpty();
 

--- a/src/main/java/world/bentobox/upgrades/ui/Panel.java
+++ b/src/main/java/world/bentobox/upgrades/ui/Panel.java
@@ -1,10 +1,15 @@
 package world.bentobox.upgrades.ui;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
-import world.bentobox.bentobox.api.panels.builders.PanelBuilder;
+import world.bentobox.bentobox.api.panels.PanelItem;
 import world.bentobox.bentobox.api.panels.builders.PanelItemBuilder;
+import world.bentobox.bentobox.api.panels.builders.TemplatedPanelBuilder;
+import world.bentobox.bentobox.api.panels.reader.ItemTemplateRecord;
+import world.bentobox.bentobox.api.panels.TemplatedPanel;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.database.objects.Island;
 import world.bentobox.upgrades.UpgradesAddon;
@@ -15,82 +20,134 @@ import world.bentobox.upgrades.api.UpgradeAPI;
  */
 public class Panel {
 
-    private UpgradesAddon addon;
-    private Island island;
+    private final UpgradesAddon addon;
+    private final Island island;
+    private int page;
 
     /**
      * Start to create a panel for this island
      * @param addon Upgrades
      * @param island island
      */
-	public Panel(UpgradesAddon addon, Island island) {
-		super();
-		this.addon = addon;
-		this.island = island;
-	}
+    public Panel(UpgradesAddon addon, Island island) {
+        super();
+        this.addon = addon;
+        this.island = island;
+        this.page = 0;
+    }
 
     /**
      * Show the GUI to the user
      * @param user user
      */
-	public void showPanel(User user) {
-        // Start the builder
-        PanelBuilder pb = new PanelBuilder().name(user.getTranslation("upgrades.ui.upgradepanel.title"));
+    public void showPanel(User user) {
+        List<UpgradeAPI> visible = addon.getAvailableUpgrades().stream()
+                .peek(u -> u.updateUpgradeValue(user, island))
+                .filter(u -> u.isShowed(user, island))
+                .collect(Collectors.toList());
 
-        // Get the island level
-		int islandLevel = this.addon.getUpgradesManager().getIslandLevel(this.island);
+        new TemplatedPanelBuilder()
+                .user(user)
+                .world(island.getWorld())
+                .template("upgrades_panel", new File(addon.getDataFolder(), "panels"))
+                .registerTypeBuilder("UPGRADE", (t, s) -> createUpgradeButton(t, s, user, visible))
+                .registerTypeBuilder("NEXT", (t, s) -> createNextButton(t, s, user, visible))
+                .registerTypeBuilder("PREVIOUS", (t, s) -> createPreviousButton(t, s, user))
+                .build();
+    }
 
-		this.addon.getAvailableUpgrades().forEach(upgrade -> {
-			upgrade.updateUpgradeValue(user, this.island);
+    private PanelItem createUpgradeButton(ItemTemplateRecord template, TemplatedPanel.ItemSlot slot,
+            User user, List<UpgradeAPI> visible) {
+        int upgradesPerPage = slot.amount("UPGRADE");
+        int index = slot.slot() + page * upgradesPerPage;
 
-			if (!upgrade.isShowed(user, this.island))
-				return;
+        if (index >= visible.size()) {
+            return null;
+        }
 
-			String ownDescription = upgrade.getOwnDescription(user);
-			List<String> fullDescription = new ArrayList<>();
+        UpgradeAPI upgrade = visible.get(index);
+        int islandLevel = addon.getUpgradesManager().getIslandLevel(island);
 
-			if (ownDescription != null) {
-				fullDescription.add(ownDescription);
-				if (upgrade.getUpgradeValues(user) != null) {
-					// Legacy: also show vault/level summary
-					fullDescription.addAll(this.getDescription(user, upgrade, islandLevel));
-				}
-			} else {
-				fullDescription.addAll(this.getDescription(user, upgrade, islandLevel));
-			}
+        String ownDescription = upgrade.getOwnDescription(user);
+        List<String> fullDescription = new ArrayList<>();
 
-			pb.item(new PanelItemBuilder().name(upgrade.getDisplayName()).icon(upgrade.getIcon())
-					.description(fullDescription).clickHandler(new PanelClick(upgrade, this.island)).build());
-		});
+        if (ownDescription != null) {
+            fullDescription.add(ownDescription);
+            if (upgrade.getUpgradeValues(user) != null) {
+                fullDescription.addAll(getDescription(user, upgrade, islandLevel));
+            }
+        } else {
+            fullDescription.addAll(getDescription(user, upgrade, islandLevel));
+        }
 
-		pb.user(user).build();
-	}
+        return new PanelItemBuilder()
+                .name(upgrade.getDisplayName())
+                .icon(upgrade.getIcon())
+                .description(fullDescription)
+                .clickHandler(new PanelClick(upgrade, island))
+                .build();
+    }
 
+    private PanelItem createNextButton(ItemTemplateRecord template, TemplatedPanel.ItemSlot slot,
+            User user, List<UpgradeAPI> visible) {
+        if ((page + 1) * slot.amount("UPGRADE") >= visible.size()) {
+            return null;
+        }
 
-	private List<String> getDescription(User user, UpgradeAPI upgrade, int islandLevel) {
-		List<String> descrip = new ArrayList<>();
+        return new PanelItemBuilder()
+                .icon(template.icon())
+                .name(template.title())
+                .description(template.description())
+                .clickHandler((panel, clicker, clickType, slotNumber) -> {
+                    page++;
+                    showPanel(clicker);
+                    return true;
+                })
+                .build();
+    }
 
-		if (upgrade.getUpgradeValues(user) == null)
-			descrip.add(user.getTranslation("upgrades.ui.upgradepanel.maxlevel"));
-		else {
-			if (this.addon.isLevelProvided()) {
-				descrip.add((upgrade.getUpgradeValues(user).getIslandLevel() <= islandLevel ? "§a" : "§c")
-						+ user.getTranslation("upgrades.ui.upgradepanel.islandneed", "[islandlevel]",
-								Integer.toString(upgrade.getUpgradeValues(user).getIslandLevel())));
-			}
+    private PanelItem createPreviousButton(ItemTemplateRecord template, TemplatedPanel.ItemSlot slot,
+            User user) {
+        if (page == 0) {
+            return null;
+        }
 
-			if (this.addon.isVaultProvided()) {
-				boolean hasMoney = this.addon.getVaultHook().has(user, upgrade.getUpgradeValues(user).getMoneyCost());
-				descrip.add((hasMoney ? "§a" : "§c") + user.getTranslation("upgrades.ui.upgradepanel.moneycost",
-						"[cost]", Integer.toString(upgrade.getUpgradeValues(user).getMoneyCost())));
-			}
+        return new PanelItemBuilder()
+                .icon(template.icon())
+                .name(template.title())
+                .description(template.description())
+                .clickHandler((panel, clicker, clickType, slotNumber) -> {
+                    page--;
+                    showPanel(clicker);
+                    return true;
+                })
+                .build();
+    }
 
-			if (this.addon.isLevelProvided() && upgrade.getUpgradeValues(user).getIslandLevel() > islandLevel) {
-				descrip.add("§8" + user.getTranslation("upgrades.ui.upgradepanel.tryreloadlevel"));
-			}
-		}
+    private List<String> getDescription(User user, UpgradeAPI upgrade, int islandLevel) {
+        List<String> descrip = new ArrayList<>();
 
-		return descrip;
-	}
+        if (upgrade.getUpgradeValues(user) == null)
+            descrip.add(user.getTranslation("upgrades.ui.upgradepanel.maxlevel"));
+        else {
+            if (this.addon.isLevelProvided()) {
+                descrip.add((upgrade.getUpgradeValues(user).getIslandLevel() <= islandLevel ? "§a" : "§c")
+                        + user.getTranslation("upgrades.ui.upgradepanel.islandneed", "[islandlevel]",
+                                Integer.toString(upgrade.getUpgradeValues(user).getIslandLevel())));
+            }
+
+            if (this.addon.isVaultProvided()) {
+                boolean hasMoney = this.addon.getVaultHook().has(user, upgrade.getUpgradeValues(user).getMoneyCost());
+                descrip.add((hasMoney ? "§a" : "§c") + user.getTranslation("upgrades.ui.upgradepanel.moneycost",
+                        "[cost]", Integer.toString(upgrade.getUpgradeValues(user).getMoneyCost())));
+            }
+
+            if (this.addon.isLevelProvided() && upgrade.getUpgradeValues(user).getIslandLevel() > islandLevel) {
+                descrip.add("§8" + user.getTranslation("upgrades.ui.upgradepanel.tryreloadlevel"));
+            }
+        }
+
+        return descrip;
+    }
 
 }

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -56,6 +56,16 @@ upgrades:
       tiernameandlevel: "&e&o&l[name]&e &7(&a[current] &7/ &2[max]&7)"
       title: "Island upgrade shop"
       tryreloadlevel: "Don't forget to update your island level with the level command"
+      previous:
+        name: "&7Previous page"
+        description: "&7Go to previous page"
+        tooltip: "Click to go to previous page"
+      next:
+        name: "&7Next page"
+        description: "&7Go to next page"
+        tooltip: "Click to go to next page"
+      upgrade:
+        tooltip: "Click to purchase upgrade"
     editupgradepanel:
       active: "Active"
       activedesc: "Click to turn inactive"

--- a/src/main/resources/panels/upgrades_panel.yml
+++ b/src/main/resources/panels/upgrades_panel.yml
@@ -1,0 +1,64 @@
+upgrades_panel:
+  title: upgrades.ui.upgradepanel.title
+  type: INVENTORY
+  background:
+    icon: BLACK_STAINED_GLASS_PANE
+    title: " "
+  border:
+    icon: BLACK_STAINED_GLASS_PANE
+    title: " "
+  force-shown: []
+  content:
+    1:
+      1: upgrade_button
+      2: upgrade_button
+      3: upgrade_button
+      4: upgrade_button
+      5: upgrade_button
+      6: upgrade_button
+      7: upgrade_button
+    2:
+      1: upgrade_button
+      2: upgrade_button
+      3: upgrade_button
+      4: upgrade_button
+      5: upgrade_button
+      6: upgrade_button
+      7: upgrade_button
+    3:
+      1: upgrade_button
+      2: upgrade_button
+      3: upgrade_button
+      4: upgrade_button
+      5: upgrade_button
+      6: upgrade_button
+      7: upgrade_button
+    5:
+      3:
+        icon: ARROW
+        title: upgrades.ui.upgradepanel.previous.name
+        description: upgrades.ui.upgradepanel.previous.description
+        data:
+          type: PREVIOUS
+        actions:
+          previous:
+            click-type: UNKNOWN
+            tooltip: upgrades.ui.upgradepanel.previous.tooltip
+      5:
+        icon: ARROW
+        title: upgrades.ui.upgradepanel.next.name
+        description: upgrades.ui.upgradepanel.next.description
+        data:
+          type: NEXT
+        actions:
+          next:
+            click-type: UNKNOWN
+            tooltip: upgrades.ui.upgradepanel.next.tooltip
+  reusable:
+    upgrade_button:
+      data:
+        type: UPGRADE
+      actions:
+        upgrade:
+          click-type: UNKNOWN
+          tooltip: upgrades.ui.upgradepanel.upgrade.tooltip

--- a/src/test/java/world/bentobox/upgrades/UpgradesAddonTest.java
+++ b/src/test/java/world/bentobox/upgrades/UpgradesAddonTest.java
@@ -121,15 +121,23 @@ public class UpgradesAddonTest {
         Path path = Paths.get("config.yml");
         Files.copy(fromPath, path);
         try (JarOutputStream tempJarOutputStream = new JarOutputStream(new FileOutputStream(jFile))) {
-            //Added the new files to the jar.
-            try (FileInputStream fis = new FileInputStream(path.toFile())) {
-                byte[] buffer = new byte[1024];
-                int bytesRead = 0;
-                JarEntry entry = new JarEntry(path.toString());
-                tempJarOutputStream.putNextEntry(entry);
-                while ((bytesRead = fis.read(buffer)) != -1) {
-                    tempJarOutputStream.write(buffer, 0, bytesRead);
-                }
+            // Add config.yml
+            addFileToJar(tempJarOutputStream, path.toFile(), "config.yml");
+            // Add panel template
+            addFileToJar(tempJarOutputStream,
+                    Paths.get("src/main/resources/panels/upgrades_panel.yml").toFile(),
+                    "panels/upgrades_panel.yml");
+        }
+    }
+
+    private static void addFileToJar(JarOutputStream jar, File file, String entryName) throws IOException {
+        try (FileInputStream fis = new FileInputStream(file)) {
+            byte[] buffer = new byte[1024];
+            int bytesRead;
+            JarEntry entry = new JarEntry(entryName);
+            jar.putNextEntry(entry);
+            while ((bytesRead = fis.read(buffer)) != -1) {
+                jar.write(buffer, 0, bytesRead);
             }
         }
     }

--- a/src/test/java/world/bentobox/upgrades/ui/PanelTest.java
+++ b/src/test/java/world/bentobox/upgrades/ui/PanelTest.java
@@ -7,6 +7,12 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.UUID;
 
 import org.bukkit.Bukkit;
@@ -23,11 +29,13 @@ import org.mockito.MockedStatic;
 import org.mockito.MockitoAnnotations;
 import org.mockito.Mockito;
 
+import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.database.objects.Island;
 import world.bentobox.bentobox.managers.IslandsManager;
 import world.bentobox.upgrades.UpgradesAddon;
 import world.bentobox.upgrades.UpgradesManager;
+import world.bentobox.upgrades.WhiteBox;
 
 /**
  * @author tastybento
@@ -44,6 +52,8 @@ public class PanelTest {
     private World world;
     @Mock
     private User user;
+    @Mock
+    private BentoBox plugin;
 
     private UUID uuid;
     @Mock
@@ -54,6 +64,7 @@ public class PanelTest {
     private Player p;
     private Panel panel;
     private MockedStatic<Bukkit> mockBukkit;
+    private File dataFolder;
 
     /**
      * @throws java.lang.Exception
@@ -62,10 +73,13 @@ public class PanelTest {
     public void setUp() throws Exception {
         MockitoAnnotations.openMocks(this);
         MockBukkit.mock();
+
+        // Set up BentoBox singleton (needed for TemplatedPanel internal error logging)
+        WhiteBox.setInternalState(BentoBox.class, "instance", plugin);
+
         // World
         when(world.toString()).thenReturn("world");
         // Player
-        // Sometimes use Mockito.withSettings().verboseLogging()
         when(user.isOp()).thenReturn(false);
         uuid = UUID.randomUUID();
         when(user.getUniqueId()).thenReturn(uuid);
@@ -78,6 +92,16 @@ public class PanelTest {
 
         when(um.getIslandLevel(island)).thenReturn(20);
         when(addon.getUpgradesManager()).thenReturn(um);
+        when(addon.getAvailableUpgrades()).thenReturn(Collections.emptySet());
+        when(island.getWorld()).thenReturn(world);
+
+        // Set up data folder with panel template
+        dataFolder = Files.createTempDirectory("upgrades-panel-test").toFile();
+        File panelsDir = new File(dataFolder, "panels");
+        panelsDir.mkdirs();
+        Files.copy(Paths.get("src/main/resources/panels/upgrades_panel.yml"),
+                new File(panelsDir, "upgrades_panel.yml").toPath());
+        when(addon.getDataFolder()).thenReturn(dataFolder);
 
         // Bukkit
         mockBukkit = Mockito.mockStatic(Bukkit.class, Mockito.RETURNS_MOCKS);
@@ -91,8 +115,15 @@ public class PanelTest {
     @AfterEach
     public void tearDown() throws Exception {
         User.clearUsers();
+        WhiteBox.setInternalState(BentoBox.class, "instance", null);
         mockBukkit.closeOnDemand();
         MockBukkit.unmock();
+        if (dataFolder != null) {
+            Files.walk(dataFolder.toPath())
+                    .sorted(Comparator.reverseOrder())
+                    .map(java.nio.file.Path::toFile)
+                    .forEach(File::delete);
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary
- Replaces the programmatic `PanelBuilder` in `Panel.java` with a YAML-driven `TemplatedPanelBuilder`, separating layout from logic
- Adds `src/main/resources/panels/upgrades_panel.yml` — a default 6-row layout with 3×7 upgrade slots (21 per page) and PREVIOUS/NEXT pagination buttons in the bottom row
- `UpgradesAddon.onEnable` now calls `saveResource("panels/upgrades_panel.yml", false)` to copy the template on first run without overwriting admin edits
- Adds `previous`, `next`, and `upgrade` tooltip locale keys under `upgradepanel` in `en-US.yml`

## Admin customisation
Admins can edit `plugins/BentoBox/addons/Upgrades/panels/upgrades_panel.yml` to rearrange slots, change icons, add rows, etc. — no code changes needed.

## Pagination
More than 21 upgrades automatically gets a NEXT button on page 1 and a PREVIOUS button on page 2+. Each page shows 21 upgrades (3 rows × 7 cols).

## Test plan
- [x] All 102 existing tests pass (`mvn test`)
- [ ] In-game: `/[gamemode] upgrades` opens the panel with upgrades in the grid
- [ ] With >21 upgrades: NEXT/PREVIOUS pagination works correctly
- [ ] Edit `upgrades_panel.yml` and reload — layout changes take effect

🤖 Generated with [Claude Code](https://claude.com/claude-code)