### PR TITLE
Fix NoSuchMethodError with Limits 1.28.1+ and bump version to 1.0.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <paper.version>1.21.11-R0.1-SNAPSHOT</paper.version>
         <bentobox.version>3.14.0</bentobox.version>
         <level.version>2.17.0</level.version>
-        <limits.version>1.28.0-SNAPSHOT</limits.version>
+        <limits.version>1.29.1</limits.version>
         <vault.version>1.7</vault.version>
 
         <revision>${build.version}-SNAPSHOT</revision>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <revision>${build.version}-SNAPSHOT</revision>
 
         <!-- This allows to change between versions. -->
-        <build.version>1.0.3</build.version>
+        <build.version>1.0.4</build.version>
         <!-- Revision variable removes warning about dynamic version -->
         <revision>${build.version}-SNAPSHOT</revision>
         <!-- Do not change unless you want different name for local builds. -->

--- a/src/main/java/world/bentobox/upgrades/UpgradesManager.java
+++ b/src/main/java/world/bentobox/upgrades/UpgradesManager.java
@@ -15,6 +15,7 @@ import java.util.stream.Collectors;
 
 import org.bukkit.Material;
 import org.bukkit.World;
+import org.bukkit.World.Environment;
 import org.bukkit.entity.EntityType;
 
 import world.bentobox.bentobox.api.addons.GameModeAddon;
@@ -640,13 +641,14 @@ public class UpgradesManager {
         if (!this.addon.isLimitsProvided())
             return Collections.emptyMap();
 
+        Environment env = island.getWorld().getEnvironment();
         Map<EntityType, Integer> entityLimits = new HashMap<>(this.addon.getLimitsAddon()
                 .getSettings()
-                .getLimits());
+                .getLimits(env));
         IslandBlockCount ibc = this.addon.getLimitsAddon()
                 .getBlockLimitListener()
                 .getIsland(island.getUniqueId());
-        if (ibc != null) ibc.getEntityLimits()
+        if (ibc != null) ibc.getEntityLimits(env)
                 .forEach(entityLimits::put);
         return entityLimits;
     }
@@ -666,7 +668,7 @@ public class UpgradesManager {
         IslandBlockCount ibc = this.addon.getLimitsAddon()
                 .getBlockLimitListener()
                 .getIsland(island.getUniqueId());
-        if (ibc != null) ibc.getEntityGroupLimits()
+        if (ibc != null) ibc.getEntityGroupLimits(island.getWorld().getEnvironment())
                 .forEach(entityGroupLimits::put);
         return entityGroupLimits;
     }

--- a/src/main/java/world/bentobox/upgrades/dataobjects/rewards/LimitsReward.java
+++ b/src/main/java/world/bentobox/upgrades/dataobjects/rewards/LimitsReward.java
@@ -1,6 +1,7 @@
 package world.bentobox.upgrades.dataobjects.rewards;
 
 import org.bukkit.Material;
+import org.bukkit.World.Environment;
 import org.bukkit.entity.EntityType;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
@@ -80,12 +81,15 @@ public class LimitsReward extends Reward {
             return;
         }
 
+        // Upgrades are island-wide, so raise the offset in every environment
         switch (db.getLimitType().toUpperCase()) {
             case "BLOCK" -> {
                 try {
                     Material mat = Material.valueOf(db.getTarget().toUpperCase());
-                    int oldCount = isb.getBlockLimitsOffset().getOrDefault(mat.getKey(), 0);
-                    isb.setBlockLimitsOffset(mat.getKey(), oldCount + amount);
+                    for (Environment env : Environment.values()) {
+                        isb.setBlockLimitsOffset(env, mat.getKey(),
+                                isb.getBlockLimitOffset(env, mat.getKey()) + amount);
+                    }
                 } catch (IllegalArgumentException e) {
                     addon.logWarning("LimitsReward: invalid material '" + db.getTarget() + "'");
                 }
@@ -93,15 +97,18 @@ public class LimitsReward extends Reward {
             case "ENTITY" -> {
                 try {
                     EntityType et = EntityType.valueOf(db.getTarget().toUpperCase());
-                    int oldCount = isb.getEntityLimitsOffset().getOrDefault(et, 0);
-                    isb.setEntityLimitsOffset(et, oldCount + amount);
+                    for (Environment env : Environment.values()) {
+                        isb.setEntityLimitsOffset(env, et, isb.getEntityLimitOffset(env, et) + amount);
+                    }
                 } catch (IllegalArgumentException e) {
                     addon.logWarning("LimitsReward: invalid entity type '" + db.getTarget() + "'");
                 }
             }
             case "ENTITY_GROUP" -> {
-                int oldCount = isb.getEntityGroupLimitsOffset().getOrDefault(db.getTarget(), 0);
-                isb.setEntityGroupLimitsOffset(db.getTarget(), oldCount + amount);
+                for (Environment env : Environment.values()) {
+                    isb.setEntityGroupLimitsOffset(env, db.getTarget(),
+                            isb.getEntityGroupLimitOffset(env, db.getTarget()) + amount);
+                }
             }
             default -> addon.logWarning("LimitsReward: unknown limit type '" + db.getLimitType() + "'");
         }

--- a/src/main/java/world/bentobox/upgrades/upgrades/BlockLimitsUpgrade.java
+++ b/src/main/java/world/bentobox/upgrades/upgrades/BlockLimitsUpgrade.java
@@ -4,6 +4,7 @@ import java.util.Map;
 
 import org.apache.commons.lang.math.NumberUtils;
 import org.bukkit.Material;
+import org.bukkit.World.Environment;
 import org.bukkit.entity.Player;
 import org.bukkit.permissions.PermissionAttachmentInfo;
 
@@ -140,9 +141,11 @@ public class BlockLimitsUpgrade extends UpgradeAPI {
         if (!super.doUpgrade(user, island))
             return false;
 
-        int oldCount = isb.getBlockLimitsOffset().getOrDefault(block.getKey(), 0);
-        int newCount = oldCount + this.getUpgradeValues(user).getUpgradeValue();
-        isb.setBlockLimitsOffset(block.getKey(), newCount);
+        // Upgrades are island-wide, so raise the offset in every environment
+        int amount = this.getUpgradeValues(user).getUpgradeValue();
+        for (Environment env : Environment.values()) {
+            isb.setBlockLimitsOffset(env, block.getKey(), isb.getBlockLimitOffset(env, block.getKey()) + amount);
+        }
 
         user.sendMessage("upgrades.ui.upgradepanel.limitsupgradedone", BLOCK, this.block.toString(), LEVEL,
                 Integer.toString(this.getUpgradeValues(user).getUpgradeValue()));

--- a/src/main/java/world/bentobox/upgrades/upgrades/BlockLimitsUpgrade.java
+++ b/src/main/java/world/bentobox/upgrades/upgrades/BlockLimitsUpgrade.java
@@ -2,25 +2,19 @@ package world.bentobox.upgrades.upgrades;
 
 import java.util.Map;
 
-import org.apache.commons.lang.math.NumberUtils;
 import org.bukkit.Material;
+import org.bukkit.World;
 import org.bukkit.World.Environment;
-import org.bukkit.entity.Player;
-import org.bukkit.permissions.PermissionAttachmentInfo;
 
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.database.objects.Island;
 
-import world.bentobox.limits.listeners.BlockLimitsListener;
 import world.bentobox.limits.objects.IslandBlockCount;
 import world.bentobox.upgrades.UpgradesAddon;
-import world.bentobox.upgrades.api.UpgradeAPI;
 import world.bentobox.upgrades.dataobjects.UpgradesData;
 
-public class BlockLimitsUpgrade extends UpgradeAPI {
+public class BlockLimitsUpgrade extends LimitsUpgrade {
 
-    private static final String BLOCK = "[block]";
-    private static final String LEVEL = "[level]";
     private Material block;
 
     public BlockLimitsUpgrade(UpgradesAddon addon, Material block) {
@@ -73,84 +67,19 @@ public class BlockLimitsUpgrade extends UpgradeAPI {
     }
 
     @Override
-    public boolean isShowed(User user, Island island) {
-        // Get the addon
-        UpgradesAddon upgradesAddon = this.getUpgradesAddon();
-        // Get the data from upgrades
-        UpgradesData islandData = upgradesAddon.getUpgradesLevels(island.getUniqueId());
-        // Get level of the upgrade
-        int upgradeLevel = islandData.getUpgradeLevel(this.getName());
-        // Permission level required
-        int permissionLevel = upgradesAddon.getUpgradesManager().getBlockLimitsPermissionLevel(this.block, upgradeLevel,
-                island.getWorld());
-
-        // If default permission, then true
-        if (permissionLevel == 0)
-            return true;
-
-        Player player = user.getPlayer();
-        String gamemode = island.getGameMode();
-        String permissionStart = gamemode + ".upgrades." + this.getName() + ".";
-        permissionStart = permissionStart.toLowerCase();
-
-        // For each permission of the player
-        for (PermissionAttachmentInfo perms : player.getEffectivePermissions()) {
-
-            // If permission is the one we search
-            if (!perms.getValue() || !perms.getPermission().startsWith(permissionStart))
-                continue;
-
-            if (perms.getPermission().contains(permissionStart + "*")) {
-                this.logError(player.getName(), perms.getPermission(), "Wildcards are not allowed.");
-                return false;
-            }
-
-            String[] split = perms.getPermission().split("\\.");
-            if (split.length != 4) {
-                logError(player.getName(), perms.getPermission(), "format must be '" + permissionStart + "LEVEL'");
-                return false;
-            }
-
-            if (!NumberUtils.isDigits(split[3])) {
-                logError(player.getName(), perms.getPermission(), "The last part must be a number");
-                return false;
-            }
-
-            if (permissionLevel <= Integer.parseInt(split[3]))
-                return true;
-        }
-
-        return false;
-    }
-
-    private void logError(String name, String perm, String error) {
-        this.getUpgradesAddon()
-        .logError("Player " + name + " has permission: '" + perm + "' but " + error + " Ignoring...");
+    protected int getPermissionLevel(int upgradeLevel, World world) {
+        return this.getUpgradesAddon().getUpgradesManager().getBlockLimitsPermissionLevel(this.block, upgradeLevel,
+                world);
     }
 
     @Override
-    public boolean doUpgrade(User user, Island island) {
-        UpgradesAddon islandAddon = this.getUpgradesAddon();
+    protected void applyOffset(IslandBlockCount isb, Environment env, int amount) {
+        isb.setBlockLimitsOffset(env, block.getKey(), isb.getBlockLimitOffset(env, block.getKey()) + amount);
+    }
 
-        if (!islandAddon.isLimitsProvided())
-            return false;
-
-        BlockLimitsListener bLListener = islandAddon.getLimitsAddon().getBlockLimitListener();
-        IslandBlockCount isb = bLListener.getIsland(island);
-
-        if (!super.doUpgrade(user, island))
-            return false;
-
-        // Upgrades are island-wide, so raise the offset in every environment
-        int amount = this.getUpgradeValues(user).getUpgradeValue();
-        for (Environment env : Environment.values()) {
-            isb.setBlockLimitsOffset(env, block.getKey(), isb.getBlockLimitOffset(env, block.getKey()) + amount);
-        }
-
-        user.sendMessage("upgrades.ui.upgradepanel.limitsupgradedone", BLOCK, this.block.toString(), LEVEL,
-                Integer.toString(this.getUpgradeValues(user).getUpgradeValue()));
-
-        return true;
+    @Override
+    protected String getTargetName() {
+        return this.block.toString();
     }
 
 }

--- a/src/main/java/world/bentobox/upgrades/upgrades/EntityGroupLimitsUpgrade.java
+++ b/src/main/java/world/bentobox/upgrades/upgrades/EntityGroupLimitsUpgrade.java
@@ -3,6 +3,7 @@ package world.bentobox.upgrades.upgrades;
 import java.util.Map;
 
 import org.apache.commons.lang.math.NumberUtils;
+import org.bukkit.World.Environment;
 import org.bukkit.entity.Player;
 import org.bukkit.permissions.PermissionAttachmentInfo;
 
@@ -175,10 +176,11 @@ public class EntityGroupLimitsUpgrade extends UpgradeAPI {
         if (!super.doUpgrade(user, island))
             return false;
 
-        int oldCount = isb.getEntityGroupLimitsOffset().getOrDefault(this.group,  0);
-        int newCount = oldCount + this.getUpgradeValues(user).getUpgradeValue();
-
-        isb.setEntityGroupLimitsOffset(this.group, newCount);
+        // Upgrades are island-wide, so raise the offset in every environment
+        int amount = this.getUpgradeValues(user).getUpgradeValue();
+        for (Environment env : Environment.values()) {
+            isb.setEntityGroupLimitsOffset(env, this.group, isb.getEntityGroupLimitOffset(env, this.group) + amount);
+        }
 
         user.sendMessage("upgrades.ui.upgradepanel.limitsupgradedone",
                 "[block]", this.group, "[level]", Integer.toString(this.getUpgradeValues(user).getUpgradeValue()));

--- a/src/main/java/world/bentobox/upgrades/upgrades/EntityGroupLimitsUpgrade.java
+++ b/src/main/java/world/bentobox/upgrades/upgrades/EntityGroupLimitsUpgrade.java
@@ -2,20 +2,16 @@ package world.bentobox.upgrades.upgrades;
 
 import java.util.Map;
 
-import org.apache.commons.lang.math.NumberUtils;
+import org.bukkit.World;
 import org.bukkit.World.Environment;
-import org.bukkit.entity.Player;
-import org.bukkit.permissions.PermissionAttachmentInfo;
 
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.database.objects.Island;
-import world.bentobox.limits.listeners.BlockLimitsListener;
 import world.bentobox.limits.objects.IslandBlockCount;
 import world.bentobox.upgrades.UpgradesAddon;
-import world.bentobox.upgrades.api.UpgradeAPI;
 import world.bentobox.upgrades.dataobjects.UpgradesData;
 
-public class EntityGroupLimitsUpgrade extends UpgradeAPI {
+public class EntityGroupLimitsUpgrade extends LimitsUpgrade {
 
     private final String group;
 
@@ -76,116 +72,29 @@ public class EntityGroupLimitsUpgrade extends UpgradeAPI {
 
         if (upgrade == null) {
             newDisplayName = user.getTranslation("upgrades.ui.upgradepanel.nolimitsupgrade",
-                    "[block]", this.group);
+                    BLOCK, this.group);
         } else {
             newDisplayName = user.getTranslation("upgrades.ui.upgradepanel.limitsupgrade",
-                    "[block]", this.group, "[level]", Integer.toString(upgrade.getUpgradeValue()));
+                    BLOCK, this.group, LEVEL, Integer.toString(upgrade.getUpgradeValue()));
         }
 
         this.setDisplayName(newDisplayName);
     }
 
-    /**
-     * Determines whether this upgrade should be displayed to the user.
-     * Checks the visibility conditions for the upgrade, including permissions and other
-     * contextual requirements, ensuring that only valid upgrades are shown.
-     *
-     * @param user The user requesting the visibility check.
-     * @param island The island associated with the upgrade.
-     * @return {@code true} if the upgrade should be displayed; {@code false} otherwise.
-     */
     @Override
-    public boolean isShowed(User user, Island island) {
-        // Get the addon
-        UpgradesAddon upgradesAddon = this.getUpgradesAddon();
-        // Get the data from upgrades
-        UpgradesData islandData = upgradesAddon.getUpgradesLevels(island.getUniqueId());
-        // Get level of the upgrade
-        int upgradeLevel = islandData.getUpgradeLevel(this.getName());
-        // Permission level required
-        int permissionLevel = upgradesAddon.getUpgradesManager().getEntityGroupLimitsPermissionLevel(this.group, upgradeLevel, island.getWorld());
-
-        // If default permission, then true
-        if (permissionLevel == 0)
-            return true;
-
-        Player player = user.getPlayer();
-        String gamemode = island.getGameMode();
-        String permissionStart = gamemode + ".upgrades." + this.getName() + ".";
-        permissionStart = permissionStart.toLowerCase();
-
-        // For each permission of the player
-        for (PermissionAttachmentInfo perms : player.getEffectivePermissions()) {
-
-            // If permission is the one we search
-            if (!perms.getValue() || !perms.getPermission().startsWith(permissionStart))
-                continue;
-
-            if (perms.getPermission().contains(permissionStart + "*")) {
-                this.logError(player.getName(), perms.getPermission(), "Wildcards are not allowed.");
-                return false;
-            }
-
-            String[] split = perms.getPermission().split("\\.");
-            if (split.length != 4) {
-                logError(player.getName(), perms.getPermission(), "format must be '" + permissionStart + "LEVEL'");
-                return false;
-            }
-
-            if (!NumberUtils.isDigits(split[3])) {
-                logError(player.getName(), perms.getPermission(), "The last part must be a number");
-                return false;
-            }
-
-            if (permissionLevel <= Integer.parseInt(split[3]))
-                return true;
-        }
-
-        return false;
+    protected int getPermissionLevel(int upgradeLevel, World world) {
+        return this.getUpgradesAddon().getUpgradesManager().getEntityGroupLimitsPermissionLevel(this.group,
+                upgradeLevel, world);
     }
 
-    /**
-     * Logs an error message for issues related to permissions or configurations.
-     *
-     * @param name The name of the player associated with the error.
-     * @param perm The permission string causing the error.
-     * @param error A description of the specific error to log.
-     */
-    private void logError(String name, String perm, String error) {
-        this.getUpgradesAddon().logError("Player " + name + " has permission: '" + perm + "' but " + error + " Ignoring...");
+    @Override
+    protected void applyOffset(IslandBlockCount isb, Environment env, int amount) {
+        isb.setEntityGroupLimitsOffset(env, this.group, isb.getEntityGroupLimitOffset(env, this.group) + amount);
     }
 
-    /**
-     * Performs the upgrade for the specified user and island.
-     * This method applies the upgrade by increasing the limits for the specified entity group
-     * and updating the island's limit data accordingly.
-     *
-     * @param user The user performing the upgrade.
-     * @param island The island on which the upgrade is applied.
-     * @return {@code true} if the upgrade was successfully applied; {@code false} otherwise.
-     */
     @Override
-    public boolean doUpgrade(User user, Island island) {
-        UpgradesAddon islandAddon = this.getUpgradesAddon();
-
-        if (!islandAddon.isLimitsProvided())
-            return false;
-
-        BlockLimitsListener bLListener = islandAddon.getLimitsAddon().getBlockLimitListener();
-        IslandBlockCount isb = bLListener.getIsland(island);
-        if (!super.doUpgrade(user, island))
-            return false;
-
-        // Upgrades are island-wide, so raise the offset in every environment
-        int amount = this.getUpgradeValues(user).getUpgradeValue();
-        for (Environment env : Environment.values()) {
-            isb.setEntityGroupLimitsOffset(env, this.group, isb.getEntityGroupLimitOffset(env, this.group) + amount);
-        }
-
-        user.sendMessage("upgrades.ui.upgradepanel.limitsupgradedone",
-                "[block]", this.group, "[level]", Integer.toString(this.getUpgradeValues(user).getUpgradeValue()));
-
-        return true;
+    protected String getTargetName() {
+        return this.group;
     }
 
 }

--- a/src/main/java/world/bentobox/upgrades/upgrades/EntityLimitsUpgrade.java
+++ b/src/main/java/world/bentobox/upgrades/upgrades/EntityLimitsUpgrade.java
@@ -3,6 +3,7 @@ package world.bentobox.upgrades.upgrades;
 import java.util.Map;
 
 import org.apache.commons.lang.math.NumberUtils;
+import org.bukkit.World.Environment;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.bukkit.permissions.PermissionAttachmentInfo;
@@ -177,10 +178,11 @@ public class EntityLimitsUpgrade extends UpgradeAPI {
         IslandBlockCount isb = bLListener.getIsland(island);
         if (!super.doUpgrade(user, island))
             return false;
-        int oldCount = isb.getEntityLimitsOffset().getOrDefault(entity, 0);
-        int newCount = oldCount + this.getUpgradeValues(user).getUpgradeValue();
-
-        isb.setEntityLimitsOffset(this.entity, newCount);
+        // Upgrades are island-wide, so raise the offset in every environment
+        int amount = this.getUpgradeValues(user).getUpgradeValue();
+        for (Environment env : Environment.values()) {
+            isb.setEntityLimitsOffset(env, this.entity, isb.getEntityLimitOffset(env, this.entity) + amount);
+        }
 
         user.sendMessage("upgrades.ui.upgradepanel.limitsupgradedone", "[block]", this.entity.toString(), "[level]",
                 Integer.toString(this.getUpgradeValues(user).getUpgradeValue()));

--- a/src/main/java/world/bentobox/upgrades/upgrades/EntityLimitsUpgrade.java
+++ b/src/main/java/world/bentobox/upgrades/upgrades/EntityLimitsUpgrade.java
@@ -2,21 +2,17 @@ package world.bentobox.upgrades.upgrades;
 
 import java.util.Map;
 
-import org.apache.commons.lang.math.NumberUtils;
+import org.bukkit.World;
 import org.bukkit.World.Environment;
 import org.bukkit.entity.EntityType;
-import org.bukkit.entity.Player;
-import org.bukkit.permissions.PermissionAttachmentInfo;
 
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.database.objects.Island;
-import world.bentobox.limits.listeners.BlockLimitsListener;
 import world.bentobox.limits.objects.IslandBlockCount;
 import world.bentobox.upgrades.UpgradesAddon;
-import world.bentobox.upgrades.api.UpgradeAPI;
 import world.bentobox.upgrades.dataobjects.UpgradesData;
 
-public class EntityLimitsUpgrade extends UpgradeAPI {
+public class EntityLimitsUpgrade extends LimitsUpgrade {
 
     /**
      * Constructs a new {@code EntityLimitsUpgrade} instance for a specific entity type.
@@ -76,118 +72,30 @@ public class EntityLimitsUpgrade extends UpgradeAPI {
         String newDisplayName;
 
         if (upgrade == null) {
-            newDisplayName = user.getTranslation("upgrades.ui.upgradepanel.nolimitsupgrade", "[block]",
+            newDisplayName = user.getTranslation("upgrades.ui.upgradepanel.nolimitsupgrade", BLOCK,
                     this.entity.toString());
         } else {
-            newDisplayName = user.getTranslation("upgrades.ui.upgradepanel.limitsupgrade", "[block]",
-                    this.entity.toString(), "[level]", Integer.toString(upgrade.getUpgradeValue()));
+            newDisplayName = user.getTranslation("upgrades.ui.upgradepanel.limitsupgrade", BLOCK,
+                    this.entity.toString(), LEVEL, Integer.toString(upgrade.getUpgradeValue()));
         }
 
         this.setDisplayName(newDisplayName);
     }
 
-    /**
-     * Determines whether this upgrade should be displayed to the user.
-     * Checks the visibility conditions for the upgrade, including permissions and other
-     * contextual requirements, ensuring that only valid upgrades are shown.
-     *
-     * @param user The user requesting the visibility check.
-     * @param island The island associated with the upgrade.
-     * @return {@code true} if the upgrade should be displayed; {@code false} otherwise.
-     */
     @Override
-    public boolean isShowed(User user, Island island) {
-        // Get the addon
-        UpgradesAddon upgradesAddon = this.getUpgradesAddon();
-        // Get the data from upgrades
-        UpgradesData islandData = upgradesAddon.getUpgradesLevels(island.getUniqueId());
-        // Get level of the upgrade
-        int upgradeLevel = islandData.getUpgradeLevel(this.getName());
-        // Permission level required
-        int permissionLevel = upgradesAddon.getUpgradesManager().getEntityLimitsPermissionLevel(this.entity,
-                upgradeLevel, island.getWorld());
-
-        // If default permission, then true
-        if (permissionLevel == 0)
-            return true;
-
-        Player player = user.getPlayer();
-        String gamemode = island.getGameMode();
-        String permissionStart = gamemode + ".upgrades." + this.getName() + ".";
-        permissionStart = permissionStart.toLowerCase();
-
-        // For each permission of the player
-        for (PermissionAttachmentInfo perms : player.getEffectivePermissions()) {
-
-            // If permission is the one we search
-            if (!perms.getValue() || !perms.getPermission().startsWith(permissionStart))
-                continue;
-
-            if (perms.getPermission().contains(permissionStart + "*")) {
-                this.logError(player.getName(), perms.getPermission(), "Wildcards are not allowed.");
-                return false;
-            }
-
-            String[] split = perms.getPermission().split("\\.");
-            if (split.length != 4) {
-                logError(player.getName(), perms.getPermission(), "format must be '" + permissionStart + "LEVEL'");
-                return false;
-            }
-
-            if (!NumberUtils.isDigits(split[3])) {
-                logError(player.getName(), perms.getPermission(), "The last part must be a number");
-                return false;
-            }
-
-            if (permissionLevel <= Integer.parseInt(split[3]))
-                return true;
-        }
-
-        return false;
+    protected int getPermissionLevel(int upgradeLevel, World world) {
+        return this.getUpgradesAddon().getUpgradesManager().getEntityLimitsPermissionLevel(this.entity, upgradeLevel,
+                world);
     }
 
-    /**
-     * Logs an error message for issues related to permissions or configurations.
-     *
-     * @param name The name of the player associated with the error.
-     * @param perm The permission string causing the error.
-     * @param error A description of the specific error to log.
-     */
-    private void logError(String name, String perm, String error) {
-        this.getUpgradesAddon()
-        .logError("Player " + name + " has permission: '" + perm + "' but " + error + " Ignoring...");
+    @Override
+    protected void applyOffset(IslandBlockCount isb, Environment env, int amount) {
+        isb.setEntityLimitsOffset(env, this.entity, isb.getEntityLimitOffset(env, this.entity) + amount);
     }
 
-    /**
-     * Performs the upgrade for the specified user and island.
-     * This method applies the upgrade by increasing the limits for the specified entity type
-     * and updating the island's limit data accordingly.
-     *
-     * @param user The user performing the upgrade.
-     * @param island The island on which the upgrade is applied.
-     * @return {@code true} if the upgrade was successfully applied; {@code false} otherwise.
-     */
     @Override
-    public boolean doUpgrade(User user, Island island) {
-        UpgradesAddon islandAddon = this.getUpgradesAddon();
-
-        if (!islandAddon.isLimitsProvided())
-            return false;
-
-        BlockLimitsListener bLListener = islandAddon.getLimitsAddon().getBlockLimitListener();
-        IslandBlockCount isb = bLListener.getIsland(island);
-        if (!super.doUpgrade(user, island))
-            return false;
-        // Upgrades are island-wide, so raise the offset in every environment
-        int amount = this.getUpgradeValues(user).getUpgradeValue();
-        for (Environment env : Environment.values()) {
-            isb.setEntityLimitsOffset(env, this.entity, isb.getEntityLimitOffset(env, this.entity) + amount);
-        }
-
-        user.sendMessage("upgrades.ui.upgradepanel.limitsupgradedone", "[block]", this.entity.toString(), "[level]",
-                Integer.toString(this.getUpgradeValues(user).getUpgradeValue()));
-
-        return true;
+    protected String getTargetName() {
+        return this.entity.toString();
     }
 
     private EntityType entity;

--- a/src/main/java/world/bentobox/upgrades/upgrades/LimitsUpgrade.java
+++ b/src/main/java/world/bentobox/upgrades/upgrades/LimitsUpgrade.java
@@ -1,0 +1,155 @@
+package world.bentobox.upgrades.upgrades;
+
+import org.apache.commons.lang.math.NumberUtils;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.World.Environment;
+import org.bukkit.entity.Player;
+import org.bukkit.permissions.PermissionAttachmentInfo;
+
+import world.bentobox.bentobox.api.user.User;
+import world.bentobox.bentobox.database.objects.Island;
+import world.bentobox.limits.objects.IslandBlockCount;
+import world.bentobox.upgrades.UpgradesAddon;
+import world.bentobox.upgrades.api.UpgradeAPI;
+import world.bentobox.upgrades.dataobjects.UpgradesData;
+
+/**
+ * Base class for upgrades backed by the Limits addon (block, entity and
+ * entity-group limits). Holds the shared permission gating and the
+ * offset-raising purchase flow; subclasses only supply the target-specific
+ * lookups.
+ */
+public abstract class LimitsUpgrade extends UpgradeAPI {
+
+    protected static final String BLOCK = "[block]";
+    protected static final String LEVEL = "[level]";
+
+    protected LimitsUpgrade(UpgradesAddon addon, String name, String displayName, Material icon) {
+        super(addon, name, displayName, icon);
+    }
+
+    /**
+     * @param upgradeLevel The current level of this upgrade on the island.
+     * @param world The world the island is in.
+     * @return The permission level required for this upgrade, or 0 if it is open to everyone.
+     */
+    protected abstract int getPermissionLevel(int upgradeLevel, World world);
+
+    /**
+     * Raises this upgrade's limit offset by {@code amount} in the given environment.
+     *
+     * @param isb The island's block count data.
+     * @param env The environment to raise the offset in.
+     * @param amount The amount to add to the current offset.
+     */
+    protected abstract void applyOffset(IslandBlockCount isb, Environment env, int amount);
+
+    /**
+     * @return The name of the limited block, entity or group, for player messages.
+     */
+    protected abstract String getTargetName();
+
+    /**
+     * Determines whether this upgrade should be displayed to the user.
+     * Checks the visibility conditions for the upgrade, including permissions and other
+     * contextual requirements, ensuring that only valid upgrades are shown.
+     *
+     * @param user The user requesting the visibility check.
+     * @param island The island associated with the upgrade.
+     * @return {@code true} if the upgrade should be displayed; {@code false} otherwise.
+     */
+    @Override
+    public boolean isShowed(User user, Island island) {
+        // Get the data from upgrades
+        UpgradesData islandData = this.getUpgradesAddon().getUpgradesLevels(island.getUniqueId());
+        // Get level of the upgrade
+        int upgradeLevel = islandData.getUpgradeLevel(this.getName());
+        // Permission level required
+        int permissionLevel = this.getPermissionLevel(upgradeLevel, island.getWorld());
+
+        // If default permission, then true
+        if (permissionLevel == 0)
+            return true;
+
+        Player player = user.getPlayer();
+        String gamemode = island.getGameMode();
+        String permissionStart = gamemode + ".upgrades." + this.getName() + ".";
+        permissionStart = permissionStart.toLowerCase();
+
+        // For each permission of the player
+        for (PermissionAttachmentInfo perms : player.getEffectivePermissions()) {
+
+            // If permission is the one we search
+            if (!perms.getValue() || !perms.getPermission().startsWith(permissionStart))
+                continue;
+
+            if (perms.getPermission().contains(permissionStart + "*")) {
+                this.logError(player.getName(), perms.getPermission(), "Wildcards are not allowed.");
+                return false;
+            }
+
+            String[] split = perms.getPermission().split("\\.");
+            if (split.length != 4) {
+                logError(player.getName(), perms.getPermission(), "format must be '" + permissionStart + "LEVEL'");
+                return false;
+            }
+
+            if (!NumberUtils.isDigits(split[3])) {
+                logError(player.getName(), perms.getPermission(), "The last part must be a number");
+                return false;
+            }
+
+            if (permissionLevel <= Integer.parseInt(split[3]))
+                return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Logs an error message for issues related to permissions or configurations.
+     *
+     * @param name The name of the player associated with the error.
+     * @param perm The permission string causing the error.
+     * @param error A description of the specific error to log.
+     */
+    private void logError(String name, String perm, String error) {
+        this.getUpgradesAddon()
+        .logError("Player " + name + " has permission: '" + perm + "' but " + error + " Ignoring...");
+    }
+
+    /**
+     * Performs the upgrade for the specified user and island.
+     * This method applies the upgrade by increasing the limits for the target
+     * and updating the island's limit data accordingly.
+     *
+     * @param user The user performing the upgrade.
+     * @param island The island on which the upgrade is applied.
+     * @return {@code true} if the upgrade was successfully applied; {@code false} otherwise.
+     */
+    @Override
+    public boolean doUpgrade(User user, Island island) {
+        UpgradesAddon islandAddon = this.getUpgradesAddon();
+
+        if (!islandAddon.isLimitsProvided())
+            return false;
+
+        IslandBlockCount isb = islandAddon.getLimitsAddon().getBlockLimitListener().getIsland(island);
+
+        if (!super.doUpgrade(user, island))
+            return false;
+
+        // Upgrades are island-wide, so raise the offset in every environment
+        int amount = this.getUpgradeValues(user).getUpgradeValue();
+        for (Environment env : Environment.values()) {
+            this.applyOffset(isb, env, amount);
+        }
+
+        user.sendMessage("upgrades.ui.upgradepanel.limitsupgradedone", BLOCK, this.getTargetName(), LEVEL,
+                Integer.toString(amount));
+
+        return true;
+    }
+
+}


### PR DESCRIPTION
## Summary
- Fixes a `NoSuchMethodError` (`IslandBlockCount.getBlockLimitsOffset()`) thrown when clicking any limits-based upgrade in the panel, reported with Limits 1.28.1+ installed
- Limits replaced its single offset maps with per-`Environment` (overworld/nether/end) maps, removing the no-arg offset methods this addon was compiled against
- Offset writes in `LimitsReward`, `BlockLimitsUpgrade`, `EntityLimitsUpgrade` and `EntityGroupLimitsUpgrade` now increment the offset in every environment, preserving the previous island-wide upgrade behaviour without clobbering per-environment offsets set by admins
- Limit lookups for display in `UpgradesManager` use the island world's environment
- Limits dependency bumped from `1.28.0-SNAPSHOT` to released `1.29.1`
- Build version bumped from 1.0.3 to 1.0.4

## Test plan
- `mvn clean package` compiles against Limits 1.29.1
- All 171 unit tests pass
- Manual check: click a limits upgrade (e.g. hopper) in `/[gamemode] upgrades` on a server running Limits 1.29.x — the upgrade should apply without console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GxCjgLNWwo2uTm6LrQ1eGA