### PR TITLE
Release 1.0.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -241,7 +241,6 @@
                 <version>3.8.1</version>
                 <configuration>
                     <release>${java.version}</release>
-                    <!-- <source>${java.version}</source> <target>${java.version}</target> -->
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/world/bentobox/upgrades/UpgradesAddon.java
+++ b/src/main/java/world/bentobox/upgrades/UpgradesAddon.java
@@ -35,7 +35,6 @@ import world.bentobox.upgrades.dataobjects.rewards.CropGrowthReward;
 import world.bentobox.upgrades.dataobjects.rewards.LimitsReward;
 import world.bentobox.upgrades.dataobjects.rewards.RangeReward;
 import world.bentobox.upgrades.dataobjects.rewards.SpawnerReward;
-import world.bentobox.upgrades.DefaultUpgradeSeeder;
 import world.bentobox.upgrades.upgrades.DatabaseUpgrade;
 import world.bentobox.upgrades.listeners.CropGrowthListener;
 import world.bentobox.upgrades.listeners.IslandChangeListener;
@@ -252,7 +251,7 @@ public class UpgradesAddon extends Addon {
     }
 
     public void refreshDatabaseUpgrades() {
-        this.upgrade.removeIf(u -> u instanceof DatabaseUpgrade);
+        this.upgrade.removeIf(DatabaseUpgrade.class::isInstance);
         this.hookedGameModes.forEach(gameModeName ->
                 this.upgradesDataManager.getUpgradeDataByGameMode(gameModeName).forEach(data -> {
                     if (data.isActive()) this.registerUpgrade(new DatabaseUpgrade(this, data));

--- a/src/main/java/world/bentobox/upgrades/UpgradesDataManager.java
+++ b/src/main/java/world/bentobox/upgrades/UpgradesDataManager.java
@@ -134,9 +134,8 @@ public class UpgradesDataManager {
 	 * Comparator used to sort the upgradeTier
 	 * Compare the startLevel, from lowest to highest
 	 */
-	private final Comparator<UpgradeTier> upgradeTierComparator = (upgrade1, upgrade2) -> {
-		return Integer.compare(upgrade1.getStartLevel(), upgrade2.getStartLevel());
-	};
+	private final Comparator<UpgradeTier> upgradeTierComparator = (upgrade1, upgrade2) ->
+		Integer.compare(upgrade1.getStartLevel(), upgrade2.getStartLevel());
 	
 	// ------------------------------------------------------------
 	// Section: Loading
@@ -196,15 +195,13 @@ public class UpgradesDataManager {
 		}
 		
 		// Check if uniqueId is already in cache and if it can overwrite it
-		if (this.upgradeDataCache.containsKey(upgrade.getUniqueId())) {
-			if (!overwrite) {
-				if (user != null)
-					user.sendMessage("upgrades.message.skipupgradeload",
-							UPGRADEID, upgrade.getUniqueId(),
-							WHAT, "data");
-				this.addon.logWarning("Tried to load " + upgrade.getUniqueId() + " but it was already loaded");
-				return false;
-			}
+		if (this.upgradeDataCache.containsKey(upgrade.getUniqueId()) && !overwrite) {
+			if (user != null)
+				user.sendMessage("upgrades.message.skipupgradeload",
+						UPGRADEID, upgrade.getUniqueId(),
+						WHAT, "data");
+			this.addon.logWarning("Tried to load " + upgrade.getUniqueId() + " but it was already loaded");
+			return false;
 		}
 		
 		// Add to cache
@@ -262,15 +259,13 @@ public class UpgradesDataManager {
 		}
 		
 		// Check if uniqueId is already in cache and if it can overwrite it
-		if (this.upgradeTierCache.containsKey(upgrade.getUniqueId())) {
-			if (!overwrite) {
-				if (user != null)
-					user.sendMessage("upgrades.message.skipupgradeload",
-							UPGRADEID, upgrade.getUniqueId(),
-							WHAT, "tier");
-				this.addon.logWarning("Tried to load " + upgrade.getUniqueId() + " but it was already loaded");
-				return false;
-			}
+		if (this.upgradeTierCache.containsKey(upgrade.getUniqueId()) && !overwrite) {
+			if (user != null)
+				user.sendMessage("upgrades.message.skipupgradeload",
+						UPGRADEID, upgrade.getUniqueId(),
+						WHAT, "tier");
+			this.addon.logWarning("Tried to load " + upgrade.getUniqueId() + " but it was already loaded");
+			return false;
 		}
 		
 		// Add to cache
@@ -379,7 +374,7 @@ public class UpgradesDataManager {
 		return this.upgradeDataCache.values().stream()
 				.filter(upgrade -> upgrade.getWorld().equals(world))
 				.sorted(this.upgradeDataComparator)
-				.collect(Collectors.toList());
+				.toList();
 	}
 	
 	/**
@@ -418,7 +413,7 @@ public class UpgradesDataManager {
 		return this.upgradeTierCache.values().stream()
 				.filter(upgrade -> upgrade.getUpgrade().equals(upgradeDataId))
 				.sorted(this.upgradeTierComparator)
-				.collect(Collectors.toList());
+				.toList();
 	}
 	
 	/**

--- a/src/main/java/world/bentobox/upgrades/UpgradesManager.java
+++ b/src/main/java/world/bentobox/upgrades/UpgradesManager.java
@@ -10,15 +10,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.TreeMap;
 import java.util.stream.Collectors;
 
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.World.Environment;
 import org.bukkit.entity.EntityType;
-
-import world.bentobox.bentobox.api.addons.GameModeAddon;
 import world.bentobox.bentobox.database.objects.Island;
 import world.bentobox.limits.objects.IslandBlockCount;
 import world.bentobox.upgrades.config.Settings;
@@ -26,6 +23,10 @@ import world.bentobox.upgrades.dataobjects.prices.Price;
 import world.bentobox.upgrades.dataobjects.rewards.Reward;
 
 public class UpgradesManager {
+
+    private static final String ISLAND_MIN_LEVEL = "islandMinLevel";
+    private static final String VAULT_COST = "vaultCost";
+    private static final String UPGRADE = "upgrade";
 
     public UpgradesManager(UpgradesAddon addon) {
         this.addon = addon;
@@ -412,15 +413,15 @@ public class UpgradesManager {
         Settings.UpgradeTier rangeUpgradeTier = this.getRangeUpgradeTier(rangeLevel, world);
 
         if (rangeUpgradeTier == null)
-            return null;
+            return Collections.emptyMap();
 
         Map<String, Integer> info = new HashMap<>();
 
-        info.put("islandMinLevel",
+        info.put(ISLAND_MIN_LEVEL,
                 (int) rangeUpgradeTier.calculateIslandMinLevel(rangeLevel, islandLevel, numberPeople));
-        info.put("vaultCost",
+        info.put(VAULT_COST,
                 (int) rangeUpgradeTier.calculateVaultCost(rangeLevel, islandLevel, numberPeople));
-        info.put("upgrade",
+        info.put(UPGRADE,
                 (int) rangeUpgradeTier.calculateUpgrade(rangeLevel, islandLevel, numberPeople));
 
         return info;
@@ -453,16 +454,16 @@ public class UpgradesManager {
                                                            World world) {
         Settings.UpgradeTier limitsUpgradeTier = this.getBlockLimitsUpgradeTier(mat, limitsLevel, world);
         if (limitsUpgradeTier == null) {
-            return null;
+            return Collections.emptyMap();
         }
 
         Map<String, Integer> info = new HashMap<>();
 
-        info.put("islandMinLevel",
+        info.put(ISLAND_MIN_LEVEL,
                 (int) limitsUpgradeTier.calculateIslandMinLevel(limitsLevel, islandLevel, numberPeople));
-        info.put("vaultCost",
+        info.put(VAULT_COST,
                 (int) limitsUpgradeTier.calculateVaultCost(limitsLevel, islandLevel, numberPeople));
-        info.put("upgrade",
+        info.put(UPGRADE,
                 (int) limitsUpgradeTier.calculateUpgrade(limitsLevel, islandLevel, numberPeople));
 
         return info;
@@ -496,16 +497,16 @@ public class UpgradesManager {
         Settings.UpgradeTier limitsUpgradeTier =
                 this.getEntityLimitsUpgradeTier(ent, limitsLevel, world);
         if (limitsUpgradeTier == null) {
-            return null;
+            return Collections.emptyMap();
         }
 
         Map<String, Integer> info = new HashMap<>();
 
-        info.put("islandMinLevel",
+        info.put(ISLAND_MIN_LEVEL,
                 (int) limitsUpgradeTier.calculateIslandMinLevel(limitsLevel, islandLevel, numberPeople));
-        info.put("vaultCost",
+        info.put(VAULT_COST,
                 (int) limitsUpgradeTier.calculateVaultCost(limitsLevel, islandLevel, numberPeople));
-        info.put("upgrade",
+        info.put(UPGRADE,
                 (int) limitsUpgradeTier.calculateUpgrade(limitsLevel, islandLevel, numberPeople));
 
         return info;
@@ -517,16 +518,16 @@ public class UpgradesManager {
         Settings.UpgradeTier limitsUpgradeTier =
                 this.getEntityGroupLimitsUpgradeTier(group, limitsLevel, world);
         if (limitsUpgradeTier == null) {
-            return null;
+            return Collections.emptyMap();
         }
 
         Map<String, Integer> info = new HashMap<>();
 
-        info.put("islandMinLevel",
+        info.put(ISLAND_MIN_LEVEL,
                 (int) limitsUpgradeTier.calculateIslandMinLevel(limitsLevel, islandLevel, numberPeople));
-        info.put("vaultCost",
+        info.put(VAULT_COST,
                 (int) limitsUpgradeTier.calculateVaultCost(limitsLevel, islandLevel, numberPeople));
-        info.put("upgrade",
+        info.put(UPGRADE,
                 (int) limitsUpgradeTier.calculateUpgrade(limitsLevel, islandLevel, numberPeople));
 
         return info;
@@ -584,16 +585,16 @@ public class UpgradesManager {
                                                        int numberPeople, World world) {
         Settings.CommandUpgradeTier cmdUpgradeTier = this.getCommandUpgradeTier(cmd, cmdLevel, world);
         if (cmdUpgradeTier == null) {
-            return null;
+            return Collections.emptyMap();
         }
 
         Map<String, Integer> info = new HashMap<>();
 
-        info.put("islandMinLevel",
+        info.put(ISLAND_MIN_LEVEL,
                 (int) cmdUpgradeTier.calculateIslandMinLevel(cmdLevel, islandLevel, numberPeople));
-        info.put("vaultCost",
+        info.put(VAULT_COST,
                 (int) cmdUpgradeTier.calculateVaultCost(cmdLevel, islandLevel, numberPeople));
-        info.put("upgrade", (int) cmdUpgradeTier.calculateUpgrade(cmdLevel, islandLevel, numberPeople));
+        info.put(UPGRADE, (int) cmdUpgradeTier.calculateUpgrade(cmdLevel, islandLevel, numberPeople));
 
         return info;
     }
@@ -642,7 +643,7 @@ public class UpgradesManager {
             return Collections.emptyMap();
 
         Environment env = island.getWorld().getEnvironment();
-        Map<EntityType, Integer> entityLimits = new HashMap<>(this.addon.getLimitsAddon()
+        Map<EntityType, Integer> entityLimits = new EnumMap<>(this.addon.getLimitsAddon()
                 .getSettings()
                 .getLimits(env));
         IslandBlockCount ibc = this.addon.getLimitsAddon()

--- a/src/main/java/world/bentobox/upgrades/api/UpgradeAPI.java
+++ b/src/main/java/world/bentobox/upgrades/api/UpgradeAPI.java
@@ -31,7 +31,7 @@ public abstract class UpgradeAPI {
      * @param displayName This is the name that is shown to the user
      * @param icon        This is the icon shown to the user
      */
-    public UpgradeAPI(UpgradesAddon addon, String name, String displayName, Material icon) {
+    protected UpgradeAPI(UpgradesAddon addon, String name, String displayName, Material icon) {
         this.name = name;
         this.displayName = displayName;
         this.icon = icon;
@@ -197,18 +197,20 @@ public abstract class UpgradeAPI {
     }
 
     /**
-     * You shouldn't override this function
+     * Upgrades are identified solely by their database name, which subclasses derive
+     * from whatever they target (block, entity, group). Subclass fields therefore add
+     * no identity of their own, so this is final.
      */
     @Override
-    public int hashCode() {
+    public final int hashCode() {
         return Objects.hash(name);
     }
 
     /**
-     * You shouldn't override this function
+     * @see #hashCode()
      */
     @Override
-    public boolean equals(Object obj) {
+    public final boolean equals(Object obj) {
         if (obj == null) {
             return false;
         }

--- a/src/main/java/world/bentobox/upgrades/command/PlayerUpgradeCommand.java
+++ b/src/main/java/world/bentobox/upgrades/command/PlayerUpgradeCommand.java
@@ -6,6 +6,7 @@ import world.bentobox.bentobox.api.commands.CompositeCommand;
 import world.bentobox.bentobox.api.localization.TextVariables;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.database.objects.Island;
+import world.bentobox.bentobox.managers.RanksManager;
 import world.bentobox.upgrades.UpgradesAddon;
 import world.bentobox.upgrades.ui.Panel;
 
@@ -48,7 +49,7 @@ public class PlayerUpgradeCommand extends CompositeCommand {
         if (!island.isAllowed(user, UpgradesAddon.UPGRADES_RANK_RIGHT)) {
             user.sendMessage("general.errors.insufficient-rank",
                     TextVariables.RANK,
-                    user.getTranslation(this.addon.getPlugin().getRanksManager().getRank(island.getRank(user))));
+                    user.getTranslation(RanksManager.getInstance().getRank(island.getRank(user))));
             return false;
         }
 

--- a/src/main/java/world/bentobox/upgrades/command/admin/AdminCommand.java
+++ b/src/main/java/world/bentobox/upgrades/command/admin/AdminCommand.java
@@ -1,21 +1,11 @@
 package world.bentobox.upgrades.command.admin;
 
-import java.util.ArrayList;
 import java.util.List;
-
-import org.bukkit.Material;
-import org.bukkit.inventory.ItemStack;
 
 import world.bentobox.bentobox.api.addons.GameModeAddon;
 import world.bentobox.bentobox.api.commands.CompositeCommand;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.upgrades.UpgradesAddon;
-import world.bentobox.upgrades.dataobjects.UpgradeData;
-import world.bentobox.upgrades.dataobjects.UpgradeTier;
-import world.bentobox.upgrades.dataobjects.prices.IslandLevelPrice;
-import world.bentobox.upgrades.dataobjects.prices.Price;
-import world.bentobox.upgrades.dataobjects.rewards.RangeReward;
-import world.bentobox.upgrades.dataobjects.rewards.Reward;
 import world.bentobox.upgrades.ui.admin.AdminPanel;
 
 public class AdminCommand extends CompositeCommand {
@@ -37,25 +27,6 @@ public class AdminCommand extends CompositeCommand {
 	
 	@Override
 	public boolean execute(User user, String label, List<String> args) {
-		/*UpgradeData upgrade = this.addon.getUpgradeDataManager().createUpgradeData("testUpgradeId", getWorld(), user);
-		upgrade.setIcon(new ItemStack(Material.GOLD_BLOCK));
-		upgrade.setName("Test upgrade");
-		this.addon.getUpgradeDataManager().saveUpgradeData(upgrade);
-		IslandLevelPrice price = new IslandLevelPrice();
-		List<Price> prices = new ArrayList<Price>();
-		prices.add(price);
-		price.setLevelNeededEquation("3");
-		RangeReward reward = new RangeReward();
-		List<Reward> rewards = new ArrayList<Reward>();
-		rewards.add(reward);
-		reward.setRangeUpgradeEquation("5");
-		UpgradeTier tier = this.addon.getUpgradeDataManager().createUpgradeTier("testtierid", upgrade, 0, 5, user);
-		tier.setIcon(new ItemStack(Material.GOLD_INGOT));
-		tier.setName("Test tier");
-		tier.setPrices(prices);
-		tier.setRewards(rewards);
-		this.addon.getUpgradeDataManager().saveUpgradeTier(tier);*/
-		
 		if (user.isPlayer()) {
 			new AdminPanel(this.addon, this.gameMode, user).getBuild().build();
 			return true;

--- a/src/main/java/world/bentobox/upgrades/config/FormulaParseException.java
+++ b/src/main/java/world/bentobox/upgrades/config/FormulaParseException.java
@@ -1,0 +1,16 @@
+package world.bentobox.upgrades.config;
+
+/**
+ * Thrown when an upgrade formula from the config cannot be parsed. Extends
+ * {@link RuntimeException} so existing callers that guard formula evaluation with a
+ * broad catch keep working.
+ */
+public class FormulaParseException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    public FormulaParseException(String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/world/bentobox/upgrades/config/Settings.java
+++ b/src/main/java/world/bentobox/upgrades/config/Settings.java
@@ -195,9 +195,21 @@ public class Settings {
         this.hasRangeUpgrade = false;
 
         this.disabledGameModes = new HashSet<>(this.addon.getConfig().getStringList("disabled-gamemodes"));
-        
+
         this.chatInputEscape = this.addon.getConfig().getString("chat-input-escape", "END");
 
+        loadRangeUpgrades();
+        loadBlockLimitsUpgrades();
+        loadEntityIcons();
+        loadEntityGroupIcons();
+        loadEntityLimitsUpgrades();
+        loadEntityGroupLimitsUpgrades();
+        loadCommandIcons();
+        loadCommandUpgrades();
+        loadGameModeOverrides();
+    }
+
+    private void loadRangeUpgrades() {
         if (this.addon.getConfig().isSet(RANGE_UPGRADE)) {
             ConfigurationSection section = this.addon.getConfig().getConfigurationSection(RANGE_UPGRADE);
             for (String key : Objects.requireNonNull(section).getKeys(false)) {
@@ -210,12 +222,16 @@ public class Settings {
                 this.rangeUpgradeTierMap.put(key, newUpgrade);
             }
         }
+    }
 
+    private void loadBlockLimitsUpgrades() {
         if (this.addon.getConfig().isSet(BLOCK_LIMITS_UPGRADE)) {
             ConfigurationSection section = this.addon.getConfig().getConfigurationSection(BLOCK_LIMITS_UPGRADE);
             this.blockLimitsUpgradeTierMap = this.loadBlockLimits(section, null);
         }
+    }
 
+    private void loadEntityIcons() {
         if (this.addon.getConfig().isSet("entity-icon")) {
             ConfigurationSection section = this.addon.getConfig().getConfigurationSection("entity-icon");
             for (String entity : Objects.requireNonNull(section).getKeys(false)) {
@@ -230,7 +246,9 @@ public class Settings {
                     this.entityIcon.put(ent, mat);
             }
         }
+    }
 
+    private void loadEntityGroupIcons() {
         if (this.addon.getConfig().isSet("entity-group-icon")) {
             ConfigurationSection section = this.addon.getConfig().getConfigurationSection("entity-group-icon");
             for (String group : Objects.requireNonNull(section).getKeys(false)) {
@@ -242,18 +260,24 @@ public class Settings {
                     this.entityGroupIcon.put(group, mat);
             }
         }
+    }
 
+    private void loadEntityLimitsUpgrades() {
         if (this.addon.getConfig().isSet(ENTITY_LIMITS_UPGRADE)) {
             ConfigurationSection section = this.addon.getConfig().getConfigurationSection(ENTITY_LIMITS_UPGRADE);
             this.entityLimitsUpgradeTierMap = this.loadEntityLimits(section, null);
         }
+    }
 
+    private void loadEntityGroupLimitsUpgrades() {
         if (this.addon.getConfig().isSet(ENTITY_GROUP_LIMITS_UPGRADE)) {
             ConfigurationSection section = this.addon.getConfig()
                     .getConfigurationSection(ENTITY_GROUP_LIMITS_UPGRADE);
             this.entityGroupLimitsUpgradeTierMap = this.loadEntityGroupLimits(section, null);
         }
+    }
 
+    private void loadCommandIcons() {
         if (this.addon.getConfig().isSet("command-icon")) {
             ConfigurationSection section = this.addon.getConfig().getConfigurationSection("command-icon");
             for (String commandId : Objects.requireNonNull(section).getKeys(false)) {
@@ -265,58 +289,77 @@ public class Settings {
                     this.commandIcon.put(commandId, mat);
             }
         }
+    }
 
+    private void loadCommandUpgrades() {
         if (this.addon.getConfig().isSet(COMMAND_UPGRADE)) {
             ConfigurationSection section = this.addon.getConfig().getConfigurationSection(COMMAND_UPGRADE);
             this.commandUpgradeTierMap = this.loadCommand(section, null);
         }
+    }
 
+    private void loadGameModeOverrides() {
         if (this.addon.getConfig().isSet("gamemodes")) {
             ConfigurationSection section = this.addon.getConfig().getConfigurationSection("gamemodes");
 
             for (String gameMode : Objects.requireNonNull(section).getKeys(false)) {
                 ConfigurationSection gameModeSection = section.getConfigurationSection(gameMode);
-
-                if (gameModeSection.isSet(RANGE_UPGRADE)) {
-                    ConfigurationSection lowSection = gameModeSection.getConfigurationSection(RANGE_UPGRADE);
-                    for (String key : Objects.requireNonNull(lowSection).getKeys(false)) {
-                        UpgradeTier newUpgrade = addUpgradeSection(lowSection, key);
-
-                        if (this.customMaxRangeUpgrade.get(gameMode) == null
-                                || this.customMaxRangeUpgrade.get(gameMode) < newUpgrade.getMaxLevel())
-                            this.customMaxRangeUpgrade.put(gameMode, newUpgrade.getMaxLevel());
-
-                        this.hasRangeUpgrade = true;
-
-                        this.customRangeUpgradeTierMap.computeIfAbsent(gameMode, k -> new TreeMap<>()).put(key,
-                                newUpgrade);
-                    }
-                }
-
-                if (gameModeSection.isSet(BLOCK_LIMITS_UPGRADE)) {
-                    ConfigurationSection lowSection = gameModeSection.getConfigurationSection(BLOCK_LIMITS_UPGRADE);
-                    this.customBlockLimitsUpgradeTierMap.computeIfAbsent(gameMode,
-                            k -> loadBlockLimits(lowSection, gameMode));
-                }
-
-                if (gameModeSection.isSet(ENTITY_LIMITS_UPGRADE)) {
-                    ConfigurationSection lowSection = gameModeSection.getConfigurationSection(ENTITY_LIMITS_UPGRADE);
-                    this.customEntityLimitsUpgradeTierMap.computeIfAbsent(gameMode,
-                            k -> loadEntityLimits(lowSection, gameMode));
-                }
-
-                if (gameModeSection.isSet(ENTITY_GROUP_LIMITS_UPGRADE)) {
-                    ConfigurationSection lowSection = gameModeSection
-                            .getConfigurationSection(ENTITY_GROUP_LIMITS_UPGRADE);
-                    this.customEntityGroupLimitsUpgradeTierMap.computeIfAbsent(gameMode,
-                            k -> loadEntityGroupLimits(lowSection, gameMode));
-                }
-
-                if (gameModeSection.isSet(COMMAND_UPGRADE)) {
-                    ConfigurationSection lowSection = gameModeSection.getConfigurationSection(COMMAND_UPGRADE);
-                    this.customCommandUpgradeTierMap.computeIfAbsent(gameMode, k -> loadCommand(lowSection, gameMode));
-                }
+                loadGameModeRangeUpgrades(gameMode, gameModeSection);
+                loadGameModeBlockLimitsUpgrades(gameMode, gameModeSection);
+                loadGameModeEntityLimitsUpgrades(gameMode, gameModeSection);
+                loadGameModeEntityGroupLimitsUpgrades(gameMode, gameModeSection);
+                loadGameModeCommandUpgrades(gameMode, gameModeSection);
             }
+        }
+    }
+
+    private void loadGameModeRangeUpgrades(String gameMode, ConfigurationSection gameModeSection) {
+        if (gameModeSection.isSet(RANGE_UPGRADE)) {
+            ConfigurationSection lowSection = gameModeSection.getConfigurationSection(RANGE_UPGRADE);
+            for (String key : Objects.requireNonNull(lowSection).getKeys(false)) {
+                UpgradeTier newUpgrade = addUpgradeSection(lowSection, key);
+
+                if (this.customMaxRangeUpgrade.get(gameMode) == null
+                        || this.customMaxRangeUpgrade.get(gameMode) < newUpgrade.getMaxLevel())
+                    this.customMaxRangeUpgrade.put(gameMode, newUpgrade.getMaxLevel());
+
+                this.hasRangeUpgrade = true;
+
+                this.customRangeUpgradeTierMap.computeIfAbsent(gameMode, k -> new TreeMap<>()).put(key,
+                        newUpgrade);
+            }
+        }
+    }
+
+    private void loadGameModeBlockLimitsUpgrades(String gameMode, ConfigurationSection gameModeSection) {
+        if (gameModeSection.isSet(BLOCK_LIMITS_UPGRADE)) {
+            ConfigurationSection lowSection = gameModeSection.getConfigurationSection(BLOCK_LIMITS_UPGRADE);
+            this.customBlockLimitsUpgradeTierMap.computeIfAbsent(gameMode,
+                    k -> loadBlockLimits(lowSection, gameMode));
+        }
+    }
+
+    private void loadGameModeEntityLimitsUpgrades(String gameMode, ConfigurationSection gameModeSection) {
+        if (gameModeSection.isSet(ENTITY_LIMITS_UPGRADE)) {
+            ConfigurationSection lowSection = gameModeSection.getConfigurationSection(ENTITY_LIMITS_UPGRADE);
+            this.customEntityLimitsUpgradeTierMap.computeIfAbsent(gameMode,
+                    k -> loadEntityLimits(lowSection, gameMode));
+        }
+    }
+
+    private void loadGameModeEntityGroupLimitsUpgrades(String gameMode, ConfigurationSection gameModeSection) {
+        if (gameModeSection.isSet(ENTITY_GROUP_LIMITS_UPGRADE)) {
+            ConfigurationSection lowSection = gameModeSection
+                    .getConfigurationSection(ENTITY_GROUP_LIMITS_UPGRADE);
+            this.customEntityGroupLimitsUpgradeTierMap.computeIfAbsent(gameMode,
+                    k -> loadEntityGroupLimits(lowSection, gameMode));
+        }
+    }
+
+    private void loadGameModeCommandUpgrades(String gameMode, ConfigurationSection gameModeSection) {
+        if (gameModeSection.isSet(COMMAND_UPGRADE)) {
+            ConfigurationSection lowSection = gameModeSection.getConfigurationSection(COMMAND_UPGRADE);
+            this.customCommandUpgradeTierMap.computeIfAbsent(gameMode, k -> loadCommand(lowSection, gameMode));
         }
     }
 
@@ -329,24 +372,7 @@ public class Settings {
                 ConfigurationSection matSection = section.getConfigurationSection(material);
                 for (String key : Objects.requireNonNull(matSection).getKeys(false)) {
                     UpgradeTier newUpgrade = addUpgradeSection(matSection, key);
-
-                    if (gameMode == null) {
-                        if (this.maxBlockLimitsUpgrade.get(mat) == null
-                                || this.maxBlockLimitsUpgrade.get(mat) < newUpgrade.getMaxLevel())
-                            this.maxBlockLimitsUpgrade.put(mat, newUpgrade.getMaxLevel());
-                    } else {
-                        if (this.customMaxBlockLimitsUpgrade.get(gameMode) == null) {
-                            Map<Material, Integer> newMap = new EnumMap<>(Material.class);
-                            newMap.put(mat, newUpgrade.getMaxLevel());
-                            this.customMaxBlockLimitsUpgrade.put(gameMode, newMap);
-                        } else {
-                            if (this.customMaxBlockLimitsUpgrade.get(gameMode).get(mat) == null
-                                    || this.customMaxBlockLimitsUpgrade.get(gameMode).get(mat) < newUpgrade
-                                            .getMaxLevel())
-                                this.customMaxBlockLimitsUpgrade.get(gameMode).put(mat, newUpgrade.getMaxLevel());
-                        }
-                    }
-
+                    updateMaxBlockLimitsUpgrade(mat, newUpgrade, gameMode);
                     tier.put(key, newUpgrade);
                 }
                 mats.put(mat, tier);
@@ -355,6 +381,24 @@ public class Settings {
             }
         }
         return mats;
+    }
+
+    private void updateMaxBlockLimitsUpgrade(Material mat, UpgradeTier upgrade, String gameMode) {
+        if (gameMode == null) {
+            if (this.maxBlockLimitsUpgrade.get(mat) == null
+                    || this.maxBlockLimitsUpgrade.get(mat) < upgrade.getMaxLevel())
+                this.maxBlockLimitsUpgrade.put(mat, upgrade.getMaxLevel());
+        } else {
+            if (this.customMaxBlockLimitsUpgrade.get(gameMode) == null) {
+                Map<Material, Integer> newMap = new EnumMap<>(Material.class);
+                newMap.put(mat, upgrade.getMaxLevel());
+                this.customMaxBlockLimitsUpgrade.put(gameMode, newMap);
+            } else {
+                if (this.customMaxBlockLimitsUpgrade.get(gameMode).get(mat) == null
+                        || this.customMaxBlockLimitsUpgrade.get(gameMode).get(mat) < upgrade.getMaxLevel())
+                    this.customMaxBlockLimitsUpgrade.get(gameMode).put(mat, upgrade.getMaxLevel());
+            }
+        }
     }
 
     private Map<EntityType, Map<String, UpgradeTier>> loadEntityLimits(ConfigurationSection section, String gameMode) {
@@ -366,24 +410,7 @@ public class Settings {
                 ConfigurationSection entSection = section.getConfigurationSection(entity);
                 for (String key : Objects.requireNonNull(entSection).getKeys(false)) {
                     UpgradeTier newUpgrade = addUpgradeSection(entSection, key);
-
-                    if (gameMode == null) {
-                        if (this.maxEntityLimitsUpgrade.get(ent) == null
-                                || this.maxEntityLimitsUpgrade.get(ent) < newUpgrade.getMaxLevel())
-                            this.maxEntityLimitsUpgrade.put(ent, newUpgrade.getMaxLevel());
-                    } else {
-                        if (this.customMaxEntityLimitsUpgrade.get(gameMode) == null) {
-                            Map<EntityType, Integer> newMap = new EnumMap<>(EntityType.class);
-                            newMap.put(ent, newUpgrade.getMaxLevel());
-                            this.customMaxEntityLimitsUpgrade.put(gameMode, newMap);
-                        } else {
-                            if (this.customMaxEntityLimitsUpgrade.get(gameMode).get(ent) == null
-                                    || this.customMaxEntityLimitsUpgrade.get(gameMode).get(ent) < newUpgrade
-                                            .getMaxLevel())
-                                this.customMaxEntityLimitsUpgrade.get(gameMode).put(ent, newUpgrade.getMaxLevel());
-                        }
-                    }
-
+                    updateMaxEntityLimitsUpgrade(ent, newUpgrade, gameMode);
                     tier.put(key, newUpgrade);
                 }
                 ents.put(ent, tier);
@@ -397,6 +424,24 @@ public class Settings {
         return ents;
     }
 
+    private void updateMaxEntityLimitsUpgrade(EntityType ent, UpgradeTier upgrade, String gameMode) {
+        if (gameMode == null) {
+            if (this.maxEntityLimitsUpgrade.get(ent) == null
+                    || this.maxEntityLimitsUpgrade.get(ent) < upgrade.getMaxLevel())
+                this.maxEntityLimitsUpgrade.put(ent, upgrade.getMaxLevel());
+        } else {
+            if (this.customMaxEntityLimitsUpgrade.get(gameMode) == null) {
+                Map<EntityType, Integer> newMap = new EnumMap<>(EntityType.class);
+                newMap.put(ent, upgrade.getMaxLevel());
+                this.customMaxEntityLimitsUpgrade.put(gameMode, newMap);
+            } else {
+                if (this.customMaxEntityLimitsUpgrade.get(gameMode).get(ent) == null
+                        || this.customMaxEntityLimitsUpgrade.get(gameMode).get(ent) < upgrade.getMaxLevel())
+                    this.customMaxEntityLimitsUpgrade.get(gameMode).put(ent, upgrade.getMaxLevel());
+            }
+        }
+    }
+
     private Map<String, Map<String, UpgradeTier>> loadEntityGroupLimits(ConfigurationSection section, String gameMode) {
         Map<String, Map<String, UpgradeTier>> ents = new TreeMap<>();
         for (String entitygroup : Objects.requireNonNull(section).getKeys(false)) {
@@ -404,30 +449,30 @@ public class Settings {
             ConfigurationSection entSection = section.getConfigurationSection(entitygroup);
             for (String key : Objects.requireNonNull(entSection).getKeys(false)) {
                 UpgradeTier newUpgrade = addUpgradeSection(entSection, key);
-
-                if (gameMode == null) {
-                    if (this.maxEntityGroupLimitsUpgrade.get(entitygroup) == null
-                            || this.maxEntityGroupLimitsUpgrade.get(entitygroup) < newUpgrade.getMaxLevel())
-                        this.maxEntityGroupLimitsUpgrade.put(entitygroup, newUpgrade.getMaxLevel());
-                } else {
-                    if (this.customMaxEntityGroupLimitsUpgrade.get(gameMode) == null) {
-                        Map<String, Integer> newMap = new TreeMap<>();
-                        newMap.put(entitygroup, newUpgrade.getMaxLevel());
-                        this.customMaxEntityGroupLimitsUpgrade.put(gameMode, newMap);
-                    } else {
-                        if (this.customMaxEntityGroupLimitsUpgrade.get(gameMode).get(entitygroup) == null
-                                || this.customMaxEntityGroupLimitsUpgrade.get(gameMode).get(entitygroup) < newUpgrade
-                                        .getMaxLevel())
-                            this.customMaxEntityGroupLimitsUpgrade.get(gameMode).put(entitygroup,
-                                    newUpgrade.getMaxLevel());
-                    }
-                }
-
+                updateMaxEntityGroupLimitsUpgrade(entitygroup, newUpgrade, gameMode);
                 tier.put(key, newUpgrade);
             }
             ents.put(entitygroup, tier);
         }
         return ents;
+    }
+
+    private void updateMaxEntityGroupLimitsUpgrade(String entitygroup, UpgradeTier upgrade, String gameMode) {
+        if (gameMode == null) {
+            if (this.maxEntityGroupLimitsUpgrade.get(entitygroup) == null
+                    || this.maxEntityGroupLimitsUpgrade.get(entitygroup) < upgrade.getMaxLevel())
+                this.maxEntityGroupLimitsUpgrade.put(entitygroup, upgrade.getMaxLevel());
+        } else {
+            if (this.customMaxEntityGroupLimitsUpgrade.get(gameMode) == null) {
+                Map<String, Integer> newMap = new TreeMap<>();
+                newMap.put(entitygroup, upgrade.getMaxLevel());
+                this.customMaxEntityGroupLimitsUpgrade.put(gameMode, newMap);
+            } else {
+                if (this.customMaxEntityGroupLimitsUpgrade.get(gameMode).get(entitygroup) == null
+                        || this.customMaxEntityGroupLimitsUpgrade.get(gameMode).get(entitygroup) < upgrade.getMaxLevel())
+                    this.customMaxEntityGroupLimitsUpgrade.get(gameMode).put(entitygroup, upgrade.getMaxLevel());
+            }
+        }
     }
 
     private Map<String, Map<String, CommandUpgradeTier>> loadCommand(ConfigurationSection section, String gamemode) {
@@ -443,25 +488,7 @@ public class Settings {
                         name = cmdSection.getString(key);
                     } else {
                         CommandUpgradeTier newUpgrade = addCommandUpgradeSection(cmdSection, key);
-
-                        if (gamemode == null) {
-                            if (this.maxCommandUpgrade.get(commandId) == null
-                                    || this.maxCommandUpgrade.get(commandId) < newUpgrade.getMaxLevel()) {
-                                this.maxCommandUpgrade.put(commandId, newUpgrade.getMaxLevel());
-                            }
-                        } else {
-                            if (this.customMaxCommandUpgrade.get(gamemode) == null) {
-                                Map<String, Integer> newMap = new TreeMap<>();
-                                newMap.put(commandId, newUpgrade.getMaxLevel());
-                                this.customMaxCommandUpgrade.put(gamemode, newMap);
-                            } else {
-                                if (this.customMaxCommandUpgrade.get(gamemode).get(commandId) == null
-                                        || this.customMaxCommandUpgrade.get(gamemode).get(commandId) < newUpgrade
-                                                .getMaxLevel())
-                                    this.customMaxCommandUpgrade.get(gamemode).put(commandId, newUpgrade.getMaxLevel());
-                            }
-                        }
-
+                        updateMaxCommandUpgrade(commandId, newUpgrade, gamemode);
                         tier.put(key, newUpgrade);
                     }
                 }
@@ -474,6 +501,25 @@ public class Settings {
         }
 
         return commands;
+    }
+
+    private void updateMaxCommandUpgrade(String commandId, CommandUpgradeTier upgrade, String gamemode) {
+        if (gamemode == null) {
+            if (this.maxCommandUpgrade.get(commandId) == null
+                    || this.maxCommandUpgrade.get(commandId) < upgrade.getMaxLevel()) {
+                this.maxCommandUpgrade.put(commandId, upgrade.getMaxLevel());
+            }
+        } else {
+            if (this.customMaxCommandUpgrade.get(gamemode) == null) {
+                Map<String, Integer> newMap = new TreeMap<>();
+                newMap.put(commandId, upgrade.getMaxLevel());
+                this.customMaxCommandUpgrade.put(gamemode, newMap);
+            } else {
+                if (this.customMaxCommandUpgrade.get(gamemode).get(commandId) == null
+                        || this.customMaxCommandUpgrade.get(gamemode).get(commandId) < upgrade.getMaxLevel())
+                    this.customMaxCommandUpgrade.get(gamemode).put(commandId, upgrade.getMaxLevel());
+            }
+        }
     }
 
     @NonNull
@@ -1216,27 +1262,10 @@ public class Settings {
                 if (eat('(')) { // parentheses
                     x = parseExpression();
                     eat(')');
-                } else if ((ch >= '0' && ch <= '9') || ch == '.') { // numbers
-                    while ((ch >= '0' && ch <= '9') || ch == '.')
-                        nextChar();
-                    final int innerPos = this.pos;
-                    x = (() -> Double.parseDouble(str.substring(startPos, innerPos)));
-                } else if ((ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || ch == '[' || ch == ']') { // functions
-                    while ((ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || ch == '[' || ch == ']')
-                        nextChar();
-                    String func = str.substring(startPos, this.pos);
-                    if (funct.contains(func)) {
-                        Expression a = parseFactor();
-                        x = switch (func) {
-                            case "sqrt" -> (() -> Math.sqrt(a.eval()));
-                            case "sin" -> (() -> Math.sin(Math.toRadians(a.eval())));
-                            case "cos" -> (() -> Math.cos(Math.toRadians(a.eval())));
-                            case "tan" -> (() -> Math.tan(Math.toRadians(a.eval())));
-                            default -> throw new FormulaParseException("Unknown function: " + func);
-                        };
-                    } else {
-                        x = (() -> variables.get(func));
-                    }
+                } else if (isNumberChar(ch)) { // numbers
+                    x = parseNumber(startPos);
+                } else if (isIdentifierStart(ch)) { // functions and variables
+                    x = parseFunctionOrVariable(startPos);
                 } else {
                     throw new FormulaParseException("Unexpected: " + (char) ch);
                 }
@@ -1248,6 +1277,43 @@ public class Settings {
                 }
 
                 return x;
+            }
+
+            boolean isNumberChar(int c) {
+                return (c >= '0' && c <= '9') || c == '.';
+            }
+
+            boolean isIdentifierStart(int c) {
+                return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '[' || c == ']';
+            }
+
+            Expression parseNumber(int startPos) {
+                while ((ch >= '0' && ch <= '9') || ch == '.')
+                    nextChar();
+                final int innerPos = this.pos;
+                return (() -> Double.parseDouble(str.substring(startPos, innerPos)));
+            }
+
+            Expression parseFunctionOrVariable(int startPos) {
+                while ((ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || ch == '[' || ch == ']')
+                    nextChar();
+                String func = str.substring(startPos, this.pos);
+                if (funct.contains(func)) {
+                    return parseBuiltInFunction(func);
+                } else {
+                    return (() -> variables.get(func));
+                }
+            }
+
+            Expression parseBuiltInFunction(String func) {
+                Expression a = parseFactor();
+                return switch (func) {
+                    case "sqrt" -> (() -> Math.sqrt(a.eval()));
+                    case "sin" -> (() -> Math.sin(Math.toRadians(a.eval())));
+                    case "cos" -> (() -> Math.cos(Math.toRadians(a.eval())));
+                    case "tan" -> (() -> Math.tan(Math.toRadians(a.eval())));
+                    default -> throw new FormulaParseException("Unknown function: " + func);
+                };
             }
         }.parse();
     }

--- a/src/main/java/world/bentobox/upgrades/config/Settings.java
+++ b/src/main/java/world/bentobox/upgrades/config/Settings.java
@@ -18,6 +18,7 @@ import org.eclipse.jdt.annotation.NonNull;
 
 import world.bentobox.bentobox.database.objects.Island;
 import world.bentobox.upgrades.UpgradesAddon;
+import world.bentobox.upgrades.dataobjects.FormulaVariables;
 
 /**
  * Represents the settings and configurations for the UpgradesAddon.
@@ -25,6 +26,18 @@ import world.bentobox.upgrades.UpgradesAddon;
  * managing limits for various game aspects like blocks, entities, and commands.
  */
 public class Settings {
+
+    private static final String RANGE_UPGRADE = "range-upgrade";
+    private static final String BLOCK_LIMITS_UPGRADE = "block-limits-upgrade";
+    private static final String ENTITY_LIMITS_UPGRADE = "entity-limits-upgrade";
+    private static final String ENTITY_GROUP_LIMITS_UPGRADE = "entity-group-limits-upgrade";
+    private static final String COMMAND_UPGRADE = "command-upgrade";
+    private static final String ISLAND_MIN_LEVEL = "island-min-level";
+    private static final String VAULT_COST = "vault-cost";
+    private static final String PERMISSION_LEVEL = "permission-level";
+    private static final String CONSOLE = "console";
+    private static final String CONFIG_MATERIAL = "Config: Material ";
+    private static final String NOT_VALID_MATERIAL = " is not a valid material";
 
     /**
      * The UpgradesAddon instance associated with this settings object.
@@ -185,8 +198,8 @@ public class Settings {
         
         this.chatInputEscape = this.addon.getConfig().getString("chat-input-escape", "END");
 
-        if (this.addon.getConfig().isSet("range-upgrade")) {
-            ConfigurationSection section = this.addon.getConfig().getConfigurationSection("range-upgrade");
+        if (this.addon.getConfig().isSet(RANGE_UPGRADE)) {
+            ConfigurationSection section = this.addon.getConfig().getConfigurationSection(RANGE_UPGRADE);
             for (String key : Objects.requireNonNull(section).getKeys(false)) {
                 UpgradeTier newUpgrade = addUpgradeSection(section, key);
 
@@ -198,8 +211,8 @@ public class Settings {
             }
         }
 
-        if (this.addon.getConfig().isSet("block-limits-upgrade")) {
-            ConfigurationSection section = this.addon.getConfig().getConfigurationSection("block-limits-upgrade");
+        if (this.addon.getConfig().isSet(BLOCK_LIMITS_UPGRADE)) {
+            ConfigurationSection section = this.addon.getConfig().getConfigurationSection(BLOCK_LIMITS_UPGRADE);
             this.blockLimitsUpgradeTierMap = this.loadBlockLimits(section, null);
         }
 
@@ -212,7 +225,7 @@ public class Settings {
                 if (ent == null)
                     this.addon.logError("Config: EntityType " + entity + " is not valid in icon");
                 else if (mat == null)
-                    this.addon.logError("Config: Material " + material + " is not a valid material");
+                    this.addon.logError(CONFIG_MATERIAL + material + NOT_VALID_MATERIAL);
                 else
                     this.entityIcon.put(ent, mat);
             }
@@ -224,20 +237,20 @@ public class Settings {
                 String material = section.getString(group);
                 Material mat = Material.getMaterial(material);
                 if (mat == null)
-                    this.addon.logError("Config: Material " + material + " is not a valid material");
+                    this.addon.logError(CONFIG_MATERIAL + material + NOT_VALID_MATERIAL);
                 else
                     this.entityGroupIcon.put(group, mat);
             }
         }
 
-        if (this.addon.getConfig().isSet("entity-limits-upgrade")) {
-            ConfigurationSection section = this.addon.getConfig().getConfigurationSection("entity-limits-upgrade");
+        if (this.addon.getConfig().isSet(ENTITY_LIMITS_UPGRADE)) {
+            ConfigurationSection section = this.addon.getConfig().getConfigurationSection(ENTITY_LIMITS_UPGRADE);
             this.entityLimitsUpgradeTierMap = this.loadEntityLimits(section, null);
         }
 
-        if (this.addon.getConfig().isSet("entity-group-limits-upgrade")) {
+        if (this.addon.getConfig().isSet(ENTITY_GROUP_LIMITS_UPGRADE)) {
             ConfigurationSection section = this.addon.getConfig()
-                    .getConfigurationSection("entity-group-limits-upgrade");
+                    .getConfigurationSection(ENTITY_GROUP_LIMITS_UPGRADE);
             this.entityGroupLimitsUpgradeTierMap = this.loadEntityGroupLimits(section, null);
         }
 
@@ -247,14 +260,14 @@ public class Settings {
                 String material = section.getString(commandId);
                 Material mat = Material.getMaterial(material);
                 if (mat == null)
-                    this.addon.logError("Config: Material " + material + " is not a valid material");
+                    this.addon.logError(CONFIG_MATERIAL + material + NOT_VALID_MATERIAL);
                 else
                     this.commandIcon.put(commandId, mat);
             }
         }
 
-        if (this.addon.getConfig().isSet("command-upgrade")) {
-            ConfigurationSection section = this.addon.getConfig().getConfigurationSection("command-upgrade");
+        if (this.addon.getConfig().isSet(COMMAND_UPGRADE)) {
+            ConfigurationSection section = this.addon.getConfig().getConfigurationSection(COMMAND_UPGRADE);
             this.commandUpgradeTierMap = this.loadCommand(section, null);
         }
 
@@ -264,8 +277,8 @@ public class Settings {
             for (String gameMode : Objects.requireNonNull(section).getKeys(false)) {
                 ConfigurationSection gameModeSection = section.getConfigurationSection(gameMode);
 
-                if (gameModeSection.isSet("range-upgrade")) {
-                    ConfigurationSection lowSection = gameModeSection.getConfigurationSection("range-upgrade");
+                if (gameModeSection.isSet(RANGE_UPGRADE)) {
+                    ConfigurationSection lowSection = gameModeSection.getConfigurationSection(RANGE_UPGRADE);
                     for (String key : Objects.requireNonNull(lowSection).getKeys(false)) {
                         UpgradeTier newUpgrade = addUpgradeSection(lowSection, key);
 
@@ -280,27 +293,27 @@ public class Settings {
                     }
                 }
 
-                if (gameModeSection.isSet("block-limits-upgrade")) {
-                    ConfigurationSection lowSection = gameModeSection.getConfigurationSection("block-limits-upgrade");
+                if (gameModeSection.isSet(BLOCK_LIMITS_UPGRADE)) {
+                    ConfigurationSection lowSection = gameModeSection.getConfigurationSection(BLOCK_LIMITS_UPGRADE);
                     this.customBlockLimitsUpgradeTierMap.computeIfAbsent(gameMode,
                             k -> loadBlockLimits(lowSection, gameMode));
                 }
 
-                if (gameModeSection.isSet("entity-limits-upgrade")) {
-                    ConfigurationSection lowSection = gameModeSection.getConfigurationSection("entity-limits-upgrade");
+                if (gameModeSection.isSet(ENTITY_LIMITS_UPGRADE)) {
+                    ConfigurationSection lowSection = gameModeSection.getConfigurationSection(ENTITY_LIMITS_UPGRADE);
                     this.customEntityLimitsUpgradeTierMap.computeIfAbsent(gameMode,
                             k -> loadEntityLimits(lowSection, gameMode));
                 }
 
-                if (gameModeSection.isSet("entity-group-limits-upgrade")) {
+                if (gameModeSection.isSet(ENTITY_GROUP_LIMITS_UPGRADE)) {
                     ConfigurationSection lowSection = gameModeSection
-                            .getConfigurationSection("entity-group-limits-upgrade");
+                            .getConfigurationSection(ENTITY_GROUP_LIMITS_UPGRADE);
                     this.customEntityGroupLimitsUpgradeTierMap.computeIfAbsent(gameMode,
                             k -> loadEntityGroupLimits(lowSection, gameMode));
                 }
 
-                if (gameModeSection.isSet("command-upgrade")) {
-                    ConfigurationSection lowSection = gameModeSection.getConfigurationSection("command-upgrade");
+                if (gameModeSection.isSet(COMMAND_UPGRADE)) {
+                    ConfigurationSection lowSection = gameModeSection.getConfigurationSection(COMMAND_UPGRADE);
                     this.customCommandUpgradeTierMap.computeIfAbsent(gameMode, k -> loadCommand(lowSection, gameMode));
                 }
             }
@@ -471,19 +484,19 @@ public class Settings {
         upgradeTier.setMaxLevel(tierSection.getInt("max-level"));
         upgradeTier.setUpgrade(parse(tierSection.getString("upgrade"), upgradeTier.getExpressionVariable()));
 
-        if (tierSection.isSet("island-min-level"))
+        if (tierSection.isSet(ISLAND_MIN_LEVEL))
             upgradeTier.setIslandMinLevel(
-                    parse(tierSection.getString("island-min-level"), upgradeTier.getExpressionVariable()));
+                    parse(tierSection.getString(ISLAND_MIN_LEVEL), upgradeTier.getExpressionVariable()));
         else
             upgradeTier.setIslandMinLevel(parse("0", upgradeTier.getExpressionVariable()));
 
-        if (tierSection.isSet("vault-cost"))
-            upgradeTier.setVaultCost(parse(tierSection.getString("vault-cost"), upgradeTier.getExpressionVariable()));
+        if (tierSection.isSet(VAULT_COST))
+            upgradeTier.setVaultCost(parse(tierSection.getString(VAULT_COST), upgradeTier.getExpressionVariable()));
         else
             upgradeTier.setVaultCost(parse("0", upgradeTier.getExpressionVariable()));
 
-        if (tierSection.isSet("permission-level"))
-            upgradeTier.setPermissionLevel(tierSection.getInt("permission-level"));
+        if (tierSection.isSet(PERMISSION_LEVEL))
+            upgradeTier.setPermissionLevel(tierSection.getInt(PERMISSION_LEVEL));
         else
             upgradeTier.setPermissionLevel(0);
 
@@ -499,24 +512,24 @@ public class Settings {
         upgradeTier.setMaxLevel(tierSection.getInt("max-level"));
         upgradeTier.setUpgrade(parse("0", upgradeTier.getExpressionVariable()));
 
-        if (tierSection.isSet("island-min-level"))
+        if (tierSection.isSet(ISLAND_MIN_LEVEL))
             upgradeTier.setIslandMinLevel(
-                    parse(tierSection.getString("island-min-level"), upgradeTier.getExpressionVariable()));
+                    parse(tierSection.getString(ISLAND_MIN_LEVEL), upgradeTier.getExpressionVariable()));
         else
             upgradeTier.setIslandMinLevel(parse("0", upgradeTier.getExpressionVariable()));
 
-        if (tierSection.isSet("vault-cost"))
-            upgradeTier.setVaultCost(parse(tierSection.getString("vault-cost"), upgradeTier.getExpressionVariable()));
+        if (tierSection.isSet(VAULT_COST))
+            upgradeTier.setVaultCost(parse(tierSection.getString(VAULT_COST), upgradeTier.getExpressionVariable()));
         else
             upgradeTier.setVaultCost(parse("0", upgradeTier.getExpressionVariable()));
 
-        if (tierSection.isSet("permission-level"))
-            upgradeTier.setPermissionLevel(tierSection.getInt("permission-level"));
+        if (tierSection.isSet(PERMISSION_LEVEL))
+            upgradeTier.setPermissionLevel(tierSection.getInt(PERMISSION_LEVEL));
         else
             upgradeTier.setPermissionLevel(0);
 
-        if (tierSection.isSet("console") && tierSection.isBoolean("console"))
-            upgradeTier.setConsole(tierSection.getBoolean("console"));
+        if (tierSection.isSet(CONSOLE) && tierSection.isBoolean(CONSOLE))
+            upgradeTier.setConsole(tierSection.getBoolean(CONSOLE));
         else
             upgradeTier.setConsole(false);
 
@@ -616,7 +629,7 @@ public class Settings {
     public Set<Material> getMaterialsLimitsUpgrade() {
         Set<Material> materials = new HashSet<>();
 
-        customBlockLimitsUpgradeTierMap.forEach((addon, addonUpgrade) -> materials.addAll(addonUpgrade.keySet()));
+        customBlockLimitsUpgradeTierMap.forEach((gameMode, addonUpgrade) -> materials.addAll(addonUpgrade.keySet()));
         materials.addAll(blockLimitsUpgradeTierMap.keySet());
 
         return materials;
@@ -711,7 +724,7 @@ public class Settings {
     public Set<EntityType> getEntityLimitsUpgrade() {
         Set<EntityType> entity = new HashSet<>();
 
-        customEntityLimitsUpgradeTierMap.forEach((addon, addonUpgrade) -> entity.addAll(addonUpgrade.keySet()));
+        customEntityLimitsUpgradeTierMap.forEach((gameMode, addonUpgrade) -> entity.addAll(addonUpgrade.keySet()));
         entity.addAll(entityLimitsUpgradeTierMap.keySet());
 
         return entity;
@@ -725,7 +738,7 @@ public class Settings {
     public Set<String> getEntityGroupLimitsUpgrade() {
         Set<String> groups = new HashSet<>();
 
-        customEntityGroupLimitsUpgradeTierMap.forEach((addon, addonUpgrade) -> groups.addAll(addonUpgrade.keySet()));
+        customEntityGroupLimitsUpgradeTierMap.forEach((gameMode, addonUpgrade) -> groups.addAll(addonUpgrade.keySet()));
         groups.addAll(entityGroupLimitsUpgradeTierMap.keySet());
 
         return groups;
@@ -739,10 +752,9 @@ public class Settings {
      * @return The maximum upgrade limit for the command.
      */
     public int getMaxCommandUpgrade(String commandUpgrade, String addon) {
-        if (customMaxCommandUpgrade.containsKey(addon)) {
-            if (customMaxCommandUpgrade.get(addon).containsKey(commandUpgrade)) {
-                return customMaxCommandUpgrade.get(addon).get(commandUpgrade);
-            }
+        if (customMaxCommandUpgrade.containsKey(addon)
+                && customMaxCommandUpgrade.get(addon).containsKey(commandUpgrade)) {
+            return customMaxCommandUpgrade.get(addon).get(commandUpgrade);
         }
         return maxCommandUpgrade.getOrDefault(commandUpgrade, 0);
     }
@@ -774,7 +786,7 @@ public class Settings {
     public Set<String> getCommandUpgrade() {
         Set<String> command = new HashSet<>();
 
-        customCommandUpgradeTierMap.forEach((addon, addonUpgrade) -> command.addAll(addonUpgrade.keySet()));
+        customCommandUpgradeTierMap.forEach((gameMode, addonUpgrade) -> command.addAll(addonUpgrade.keySet()));
         command.addAll(commandUpgradeTierMap.keySet());
 
         return command;
@@ -852,9 +864,9 @@ public class Settings {
         public UpgradeTier(String id) {
             this.id = id;
             this.expressionVariables = new TreeMap<>();
-            this.expressionVariables.put("[level]", 0.0);
-            this.expressionVariables.put("[islandLevel]", 0.0);
-            this.expressionVariables.put("[numberPlayer]", 0.0);
+            this.expressionVariables.put(FormulaVariables.LEVEL_VAR, 0.0);
+            this.expressionVariables.put(FormulaVariables.ISLAND_LEVEL_VAR, 0.0);
+            this.expressionVariables.put(FormulaVariables.NUMBER_PLAYER_VAR, 0.0);
         }
 
         /**
@@ -1129,7 +1141,8 @@ public class Settings {
 
     public static Expression parse(final String str, Map<String, Double> variables) {
         return new Object() {
-            int pos = -1, ch;
+            int pos = -1;
+            int ch;
 
             void nextChar() {
                 ch = (++pos < str.length()) ? str.charAt(pos) : -1;
@@ -1149,7 +1162,7 @@ public class Settings {
                 nextChar();
                 Expression x = parseExpression();
                 if (pos < str.length())
-                    throw new RuntimeException("Unexpected: " + (char) ch);
+                    throw new FormulaParseException("Unexpected: " + (char) ch);
                 return x;
             }
 
@@ -1163,10 +1176,12 @@ public class Settings {
                 Expression x = parseTerm();
                 for (;;) {
                     if (eat('+')) {
-                        Expression a = x, b = parseTerm();
+                        Expression a = x;
+                        Expression b = parseTerm();
                         x = (() -> a.eval() + b.eval());
                     } else if (eat('-')) {
-                        Expression a = x, b = parseTerm();
+                        Expression a = x;
+                        Expression b = parseTerm();
                         x = (() -> a.eval() - b.eval());
                     } else
                         return x;
@@ -1177,10 +1192,12 @@ public class Settings {
                 Expression x = parseFactor();
                 for (;;) {
                     if (eat('*')) {
-                        Expression a = x, b = parseFactor();
+                        Expression a = x;
+                        Expression b = parseFactor();
                         x = (() -> a.eval() * b.eval());
                     } else if (eat('/')) {
-                        Expression a = x, b = parseFactor();
+                        Expression a = x;
+                        Expression b = parseFactor();
                         x = (() -> a.eval() / b.eval());
                     } else
                         return x;
@@ -1215,17 +1232,18 @@ public class Settings {
                             case "sin" -> (() -> Math.sin(Math.toRadians(a.eval())));
                             case "cos" -> (() -> Math.cos(Math.toRadians(a.eval())));
                             case "tan" -> (() -> Math.tan(Math.toRadians(a.eval())));
-                            default -> throw new RuntimeException("Unknown function: " + func);
+                            default -> throw new FormulaParseException("Unknown function: " + func);
                         };
                     } else {
                         x = (() -> variables.get(func));
                     }
                 } else {
-                    throw new RuntimeException("Unexpected: " + (char) ch);
+                    throw new FormulaParseException("Unexpected: " + (char) ch);
                 }
 
                 if (eat('^')) {
-                    Expression a = x, b = parseFactor();
+                    Expression a = x;
+                    Expression b = parseFactor();
                     x = (() -> Math.pow(a.eval(), b.eval())); // exponentiation
                 }
 

--- a/src/main/java/world/bentobox/upgrades/dataobjects/FormulaVariables.java
+++ b/src/main/java/world/bentobox/upgrades/dataobjects/FormulaVariables.java
@@ -1,0 +1,57 @@
+package world.bentobox.upgrades.dataobjects;
+
+import java.util.Map;
+import java.util.TreeMap;
+
+import world.bentobox.bentobox.database.objects.Island;
+import world.bentobox.upgrades.UpgradesAddon;
+
+/**
+ * Placeholders available to the configurable price and reward formulas, and the
+ * canonical way to build the substitution map for an island.
+ */
+public final class FormulaVariables {
+
+    public static final String LEVEL_VAR = "[level]";
+    public static final String ISLAND_LEVEL_VAR = "[islandLevel]";
+    public static final String NUMBER_PLAYER_VAR = "[numberPlayer]";
+
+    private FormulaVariables() {
+        // Utility class
+    }
+
+    /**
+     * Builds the formula substitution map for an island. A null island yields zeroed
+     * island values rather than throwing, matching
+     * {@link world.bentobox.upgrades.UpgradesManager#getIslandLevel(Island)}.
+     *
+     * @param addon The addon, used to look up the island level.
+     * @param island The island the formula is being evaluated for, may be null.
+     * @param currentLevel The current level of the upgrade being evaluated.
+     * @return A mutable map of placeholder to value.
+     */
+    public static Map<String, Double> of(UpgradesAddon addon, Island island, int currentLevel) {
+        Map<String, Double> variables = new TreeMap<>();
+        variables.put(LEVEL_VAR, (double) currentLevel);
+        variables.put(ISLAND_LEVEL_VAR, (double) addon.getUpgradesManager().getIslandLevel(island));
+        variables.put(NUMBER_PLAYER_VAR, island == null ? 0d : (double) island.getMemberSet().size());
+        return variables;
+    }
+
+    /**
+     * Builds the formula substitution map from values already resolved by the caller.
+     *
+     * @param currentLevel The current level of the upgrade being evaluated.
+     * @param islandLevel The island level.
+     * @param memberCount The number of island members.
+     * @return A mutable map of placeholder to value.
+     */
+    public static Map<String, Double> of(int currentLevel, long islandLevel, int memberCount) {
+        Map<String, Double> variables = new TreeMap<>();
+        variables.put(LEVEL_VAR, (double) currentLevel);
+        variables.put(ISLAND_LEVEL_VAR, (double) islandLevel);
+        variables.put(NUMBER_PLAYER_VAR, (double) memberCount);
+        return variables;
+    }
+
+}

--- a/src/main/java/world/bentobox/upgrades/dataobjects/adapter/PriceDBAdapter.java
+++ b/src/main/java/world/bentobox/upgrades/dataobjects/adapter/PriceDBAdapter.java
@@ -17,7 +17,7 @@ public class PriceDBAdapter implements JsonSerializer<List<PriceDB>>, JsonDeseri
         List<PriceDB> list = new ArrayList<>();
         JsonArray jsonArray = json.getAsJsonArray();
 
-        jsonArray.forEach((entry) -> {
+        jsonArray.forEach(entry -> {
             JsonObject obj = entry.getAsJsonObject();
             String type = obj.get("class")
                     .getAsString();
@@ -37,7 +37,7 @@ public class PriceDBAdapter implements JsonSerializer<List<PriceDB>>, JsonDeseri
     public JsonElement serialize(List<PriceDB> src, Type typeOfSrc, JsonSerializationContext context) {
         JsonArray jsonArray = new JsonArray();
 
-        src.forEach((obj) -> {
+        src.forEach(obj -> {
             JsonObject result = new JsonObject();
 
             result.add("class", new JsonPrimitive(obj.getClass()

--- a/src/main/java/world/bentobox/upgrades/dataobjects/adapter/RewardDBAdapter.java
+++ b/src/main/java/world/bentobox/upgrades/dataobjects/adapter/RewardDBAdapter.java
@@ -18,7 +18,7 @@ public class RewardDBAdapter
         List<RewardDB> list = new ArrayList<>();
         JsonArray jsonArray = json.getAsJsonArray();
 
-        jsonArray.forEach((entry) -> {
+        jsonArray.forEach(entry -> {
             JsonObject obj = entry.getAsJsonObject();
             String type = obj.get("class")
                     .getAsString();
@@ -38,7 +38,7 @@ public class RewardDBAdapter
     public JsonElement serialize(List<RewardDB> src, Type typeOfSrc, JsonSerializationContext context) {
         JsonArray jsonArray = new JsonArray();
 
-        src.forEach((obj) -> {
+        src.forEach(obj -> {
             JsonObject result = new JsonObject();
 
             result.add("class", new JsonPrimitive(obj.getClass()

--- a/src/main/java/world/bentobox/upgrades/dataobjects/prices/IslandLevelPrice.java
+++ b/src/main/java/world/bentobox/upgrades/dataobjects/prices/IslandLevelPrice.java
@@ -9,14 +9,13 @@ import world.bentobox.bentobox.api.panels.PanelItem;
 import world.bentobox.bentobox.api.panels.builders.PanelItemBuilder;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.upgrades.UpgradesAddon;
+import world.bentobox.upgrades.dataobjects.FormulaVariables;
 import world.bentobox.upgrades.dataobjects.UpgradeTier;
 import world.bentobox.upgrades.ui.utils.AbPanel;
 
 import java.security.InvalidParameterException;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
 import java.util.function.Consumer;
 
 import world.bentobox.bentobox.database.objects.Island;
@@ -58,10 +57,7 @@ public class IslandLevelPrice extends Price {
     @Override
     public boolean canPay(UpgradesAddon addon, User user, Island island, PriceDB priceDB, int currentLevel) {
         IslandLevelPriceDB db = (IslandLevelPriceDB) priceDB;
-        Map<String, Double> variables = new TreeMap<>();
-        variables.put(LEVEL_VAR, (double) currentLevel);
-        variables.put(ISLAND_LEVEL_VAR, (double) addon.getUpgradesManager().getIslandLevel(island));
-        variables.put(NUMBER_PLAYER_VAR, (double) island.getMemberSet().size());
+        Map<String, Double> variables = FormulaVariables.of(addon, island, currentLevel);
         int required = (int) Settings.evaluate(db.getLevelNeededEquation(), variables);
         return addon.getUpgradesManager().getIslandLevel(island) >= required;
     }
@@ -82,8 +78,8 @@ public class IslandLevelPrice extends Price {
 
             prices.add(dbObject);
             tier.setPrices(prices);
-        } else if (saved instanceof IslandLevelPriceDB) {
-            dbObject = (IslandLevelPriceDB) saved;
+        } else if (saved instanceof IslandLevelPriceDB islandLevelPriceDB) {
+            dbObject = islandLevelPriceDB;
         } else {
             throw new InvalidParameterException(
                     "DB object in IslandLevelPrice which is not an IslandLevelPriceDB");
@@ -147,7 +143,7 @@ public class IslandLevelPrice extends Price {
         }
 
         private Consumer<String> doSetRule() {
-            return (rule) -> {
+            return rule -> {
                 this.saved.setLevelNeededEquation(rule);
                 this.getAddon().getUpgradeDataManager().saveUpgradeTier(this.tier);
                 this.createInterface();

--- a/src/main/java/world/bentobox/upgrades/dataobjects/prices/ItemPrice.java
+++ b/src/main/java/world/bentobox/upgrades/dataobjects/prices/ItemPrice.java
@@ -15,7 +15,6 @@ import world.bentobox.upgrades.ui.utils.AbPanel;
 
 import java.security.InvalidParameterException;
 import java.util.List;
-import java.util.function.Consumer;
 
 public class ItemPrice extends Price {
 
@@ -84,8 +83,8 @@ public class ItemPrice extends Price {
             List<PriceDB> prices = tier.getPrices();
             prices.add(dbObject);
             tier.setPrices(prices);
-        } else if (saved instanceof ItemPriceDB) {
-            dbObject = (ItemPriceDB) saved;
+        } else if (saved instanceof ItemPriceDB itemPriceDB) {
+            dbObject = itemPriceDB;
         } else {
             throw new InvalidParameterException("DB object in ItemPrice which is not an ItemPriceDB");
         }
@@ -129,7 +128,9 @@ public class ItemPrice extends Price {
             if (!this.saved.getMaterial().isEmpty()) {
                 try {
                     iconMat = Material.valueOf(this.saved.getMaterial().toUpperCase());
-                } catch (IllegalArgumentException ignored) {}
+                } catch (IllegalArgumentException ignored) {
+                    // Configured material is no longer valid; fall back to the default icon
+                }
             }
 
             this.setItems(SET_ITEM, new PanelItemBuilder()
@@ -172,7 +173,9 @@ public class ItemPrice extends Price {
                                     this.createInterface();
                                     this.getBuild().build();
                                 }
-                            } catch (NumberFormatException ignored) {}
+                            } catch (NumberFormatException ignored) {
+                                // Non-numeric input is rejected by the validator below
+                            }
                         },
                         input -> {
                             try {

--- a/src/main/java/world/bentobox/upgrades/dataobjects/prices/MoneyPrice.java
+++ b/src/main/java/world/bentobox/upgrades/dataobjects/prices/MoneyPrice.java
@@ -10,13 +10,13 @@ import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.database.objects.Island;
 import world.bentobox.upgrades.UpgradesAddon;
 import world.bentobox.upgrades.config.Settings;
+import world.bentobox.upgrades.dataobjects.FormulaVariables;
 import world.bentobox.upgrades.dataobjects.UpgradeTier;
 import world.bentobox.upgrades.ui.utils.AbPanel;
 
 import java.security.InvalidParameterException;
 import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
 import java.util.function.Consumer;
 
 public class MoneyPrice extends Price {
@@ -56,10 +56,7 @@ public class MoneyPrice extends Price {
     public boolean canPay(UpgradesAddon addon, User user, Island island, PriceDB priceDB, int currentLevel) {
         if (!addon.isVaultProvided()) return true;
         MoneyPriceDB db = (MoneyPriceDB) priceDB;
-        Map<String, Double> variables = new TreeMap<>();
-        variables.put(LEVEL_VAR, (double) currentLevel);
-        variables.put(ISLAND_LEVEL_VAR, (double) addon.getUpgradesManager().getIslandLevel(island));
-        variables.put(NUMBER_PLAYER_VAR, (double) island.getMemberSet().size());
+        Map<String, Double> variables = FormulaVariables.of(addon, island, currentLevel);
         double amount = Settings.evaluate(db.getAmountEquation(), variables);
         return addon.getVaultHook().has(user, amount);
     }
@@ -68,10 +65,7 @@ public class MoneyPrice extends Price {
     public void pay(UpgradesAddon addon, User user, Island island, PriceDB priceDB, int currentLevel) {
         if (!addon.isVaultProvided()) return;
         MoneyPriceDB db = (MoneyPriceDB) priceDB;
-        Map<String, Double> variables = new TreeMap<>();
-        variables.put(LEVEL_VAR, (double) currentLevel);
-        variables.put(ISLAND_LEVEL_VAR, (double) addon.getUpgradesManager().getIslandLevel(island));
-        variables.put(NUMBER_PLAYER_VAR, (double) island.getMemberSet().size());
+        Map<String, Double> variables = FormulaVariables.of(addon, island, currentLevel);
         double amount = Settings.evaluate(db.getAmountEquation(), variables);
         var response = addon.getVaultHook().withdraw(user, amount);
         if (!response.transactionSuccess()) {
@@ -89,8 +83,8 @@ public class MoneyPrice extends Price {
             List<PriceDB> prices = tier.getPrices();
             prices.add(dbObject);
             tier.setPrices(prices);
-        } else if (saved instanceof MoneyPriceDB) {
-            dbObject = (MoneyPriceDB) saved;
+        } else if (saved instanceof MoneyPriceDB moneyPriceDB) {
+            dbObject = moneyPriceDB;
         } else {
             throw new InvalidParameterException("DB object in MoneyPrice which is not a MoneyPriceDB");
         }
@@ -145,7 +139,7 @@ public class MoneyPrice extends Price {
         }
 
         private Consumer<String> doSetRule() {
-            return (rule) -> {
+            return rule -> {
                 this.saved.setAmountEquation(rule);
                 this.getAddon().getUpgradeDataManager().saveUpgradeTier(this.tier);
                 this.createInterface();

--- a/src/main/java/world/bentobox/upgrades/dataobjects/prices/PermissionPrice.java
+++ b/src/main/java/world/bentobox/upgrades/dataobjects/prices/PermissionPrice.java
@@ -70,8 +70,8 @@ public class PermissionPrice extends Price {
             List<PriceDB> prices = tier.getPrices();
             prices.add(dbObject);
             tier.setPrices(prices);
-        } else if (saved instanceof PermissionPriceDB) {
-            dbObject = (PermissionPriceDB) saved;
+        } else if (saved instanceof PermissionPriceDB permissionPriceDB) {
+            dbObject = permissionPriceDB;
         } else {
             throw new InvalidParameterException("DB object in PermissionPrice which is not a PermissionPriceDB");
         }
@@ -126,7 +126,7 @@ public class PermissionPrice extends Price {
         }
 
         private Consumer<String> doSetRule() {
-            return (rule) -> {
+            return rule -> {
                 this.saved.setPermission(rule);
                 this.getAddon().getUpgradeDataManager().saveUpgradeTier(this.tier);
                 this.createInterface();

--- a/src/main/java/world/bentobox/upgrades/dataobjects/prices/Price.java
+++ b/src/main/java/world/bentobox/upgrades/dataobjects/prices/Price.java
@@ -7,6 +7,7 @@ import world.bentobox.bentobox.api.addons.GameModeAddon;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.database.objects.Island;
 import world.bentobox.upgrades.UpgradesAddon;
+import world.bentobox.upgrades.dataobjects.FormulaVariables;
 import world.bentobox.upgrades.dataobjects.UpgradeTier;
 import world.bentobox.upgrades.ui.PanelAdminItem;
 import world.bentobox.upgrades.ui.PanelPublicItem;
@@ -14,14 +15,14 @@ import world.bentobox.upgrades.ui.utils.AbPanel;
 
 public abstract class Price implements PanelAdminItem, PanelPublicItem {
 
-    public static final String LEVEL_VAR = "[level]";
-    public static final String ISLAND_LEVEL_VAR = "[islandLevel]";
-    public static final String NUMBER_PLAYER_VAR = "[numberPlayer]";
+    public static final String LEVEL_VAR = FormulaVariables.LEVEL_VAR;
+    public static final String ISLAND_LEVEL_VAR = FormulaVariables.ISLAND_LEVEL_VAR;
+    public static final String NUMBER_PLAYER_VAR = FormulaVariables.NUMBER_PLAYER_VAR;
 
     private final String name;
     private final Material icon;
 
-    public Price(String name, Material icon) {
+    protected Price(String name, Material icon) {
         this.name = name;
         this.icon = icon;
     }

--- a/src/main/java/world/bentobox/upgrades/dataobjects/prices/PriceDB.java
+++ b/src/main/java/world/bentobox/upgrades/dataobjects/prices/PriceDB.java
@@ -1,12 +1,10 @@
 package world.bentobox.upgrades.dataobjects.prices;
 
-import com.google.gson.annotations.Expose;
-import world.bentobox.bentobox.database.objects.DataObject;
 
 public abstract class PriceDB {
 
-    abstract public Class<? extends Price> getPriceType();
+    public abstract Class<? extends Price> getPriceType();
 
-    abstract public boolean isValid();
+    public abstract boolean isValid();
 
 }

--- a/src/main/java/world/bentobox/upgrades/dataobjects/rewards/CommandReward.java
+++ b/src/main/java/world/bentobox/upgrades/dataobjects/rewards/CommandReward.java
@@ -1,6 +1,7 @@
 package world.bentobox.upgrades.dataobjects.rewards;
 
 import org.bukkit.Material;
+import org.bukkit.command.CommandSender;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 import world.bentobox.bentobox.api.addons.GameModeAddon;
@@ -47,18 +48,19 @@ public class CommandReward extends Reward {
         CommandRewardDB db = (CommandRewardDB) rewardDB;
         String playerName = user.getName();
         String ownerName = island.getPlugin().getPlayers().getName(island.getOwner());
-        if (ownerName == null) ownerName = "";
+
+        CommandSender sender = db.isConsole() ? addon.getServer().getConsoleSender() : user.getSender();
+        if (sender == null) {
+            addon.logWarning("CommandReward: no sender available for user " + playerName + ", skipping commands");
+            return;
+        }
 
         for (String cmd : db.getCommands()) {
             String formatted = cmd
                     .replace("[player]", playerName)
                     .replace("[owner]", ownerName);
 
-            if (db.isConsole()) {
-                addon.getServer().dispatchCommand(addon.getServer().getConsoleSender(), formatted);
-            } else {
-                addon.getServer().dispatchCommand(user.getSender(), formatted);
-            }
+            addon.getServer().dispatchCommand(sender, formatted);
         }
     }
 
@@ -72,8 +74,8 @@ public class CommandReward extends Reward {
             List<RewardDB> rewards = tier.getRewards();
             rewards.add(dbObject);
             tier.setRewards(rewards);
-        } else if (saved instanceof CommandRewardDB) {
-            dbObject = (CommandRewardDB) saved;
+        } else if (saved instanceof CommandRewardDB commandRewardDB) {
+            dbObject = commandRewardDB;
         } else {
             throw new InvalidParameterException("DB object in CommandReward which is not a CommandRewardDB");
         }

--- a/src/main/java/world/bentobox/upgrades/dataobjects/rewards/CropGrowthReward.java
+++ b/src/main/java/world/bentobox/upgrades/dataobjects/rewards/CropGrowthReward.java
@@ -10,13 +10,13 @@ import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.database.objects.Island;
 import world.bentobox.upgrades.UpgradesAddon;
 import world.bentobox.upgrades.config.Settings;
+import world.bentobox.upgrades.dataobjects.FormulaVariables;
 import world.bentobox.upgrades.dataobjects.UpgradeTier;
 import world.bentobox.upgrades.ui.utils.AbPanel;
 
 import java.security.InvalidParameterException;
 import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
 import java.util.function.Consumer;
 
 public class CropGrowthReward extends Reward {
@@ -67,8 +67,8 @@ public class CropGrowthReward extends Reward {
             List<RewardDB> rewards = tier.getRewards();
             rewards.add(dbObject);
             tier.setRewards(rewards);
-        } else if (saved instanceof CropGrowthRewardDB) {
-            dbObject = (CropGrowthRewardDB) saved;
+        } else if (saved instanceof CropGrowthRewardDB cropGrowthRewardDB) {
+            dbObject = cropGrowthRewardDB;
         } else {
             throw new InvalidParameterException(
                     "DB object in CropGrowthReward which is not a CropGrowthRewardDB");
@@ -130,10 +130,7 @@ public class CropGrowthReward extends Reward {
                         .askOneInput(this.doSetRule(),
                                 input -> {
                                     try {
-                                        Map<String, Double> vars = new TreeMap<>();
-                                        vars.put(LEVEL_VAR, 1.0);
-                                        vars.put(ISLAND_LEVEL_VAR, 1.0);
-                                        vars.put(NUMBER_PLAYER_VAR, 1.0);
+                                        Map<String, Double> vars = FormulaVariables.of(1, 1, 1);
                                         Settings.evaluate(input, vars);
                                         return true;
                                     } catch (Exception e) {
@@ -149,7 +146,7 @@ public class CropGrowthReward extends Reward {
         }
 
         private Consumer<String> doSetRule() {
-            return (rule) -> {
+            return rule -> {
                 this.saved.setGrowthBonusEquation(rule);
                 this.getAddon().getUpgradeDataManager().saveUpgradeTier(this.tier);
                 this.createInterface();

--- a/src/main/java/world/bentobox/upgrades/dataobjects/rewards/LimitsReward.java
+++ b/src/main/java/world/bentobox/upgrades/dataobjects/rewards/LimitsReward.java
@@ -14,16 +14,19 @@ import world.bentobox.limits.listeners.BlockLimitsListener;
 import world.bentobox.limits.objects.IslandBlockCount;
 import world.bentobox.upgrades.UpgradesAddon;
 import world.bentobox.upgrades.config.Settings;
+import world.bentobox.upgrades.dataobjects.FormulaVariables;
 import world.bentobox.upgrades.dataobjects.UpgradeTier;
 import world.bentobox.upgrades.ui.utils.AbPanel;
 
 import java.security.InvalidParameterException;
 import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
-import java.util.function.Consumer;
 
 public class LimitsReward extends Reward {
+
+    private static final String TYPE_BLOCK = "BLOCK";
+    private static final String TYPE_ENTITY = "ENTITY";
+    private static final String TYPE_ENTITY_GROUP = "ENTITY_GROUP";
 
     public LimitsReward() {
         super("limits_reward", Material.BARRIER);
@@ -67,23 +70,15 @@ public class LimitsReward extends Reward {
         }
 
         LimitsRewardDB db = (LimitsRewardDB) rewardDB;
-        Map<String, Double> variables = new TreeMap<>();
-        variables.put(LEVEL_VAR, (double) currentLevel);
-        variables.put(ISLAND_LEVEL_VAR, (double) addon.getUpgradesManager().getIslandLevel(island));
-        variables.put(NUMBER_PLAYER_VAR, (double) island.getMemberSet().size());
+        Map<String, Double> variables = FormulaVariables.of(addon, island, currentLevel);
         int amount = (int) Settings.evaluate(db.getAmountEquation(), variables);
 
         BlockLimitsListener bLListener = addon.getLimitsAddon().getBlockLimitListener();
         IslandBlockCount isb = bLListener.getIsland(island);
 
-        if (isb == null) {
-            addon.logWarning("LimitsReward: IslandBlockCount not found for island " + island.getUniqueId());
-            return;
-        }
-
         // Upgrades are island-wide, so raise the offset in every environment
         switch (db.getLimitType().toUpperCase()) {
-            case "BLOCK" -> {
+            case TYPE_BLOCK -> {
                 try {
                     Material mat = Material.valueOf(db.getTarget().toUpperCase());
                     for (Environment env : Environment.values()) {
@@ -94,7 +89,7 @@ public class LimitsReward extends Reward {
                     addon.logWarning("LimitsReward: invalid material '" + db.getTarget() + "'");
                 }
             }
-            case "ENTITY" -> {
+            case TYPE_ENTITY -> {
                 try {
                     EntityType et = EntityType.valueOf(db.getTarget().toUpperCase());
                     for (Environment env : Environment.values()) {
@@ -104,7 +99,7 @@ public class LimitsReward extends Reward {
                     addon.logWarning("LimitsReward: invalid entity type '" + db.getTarget() + "'");
                 }
             }
-            case "ENTITY_GROUP" -> {
+            case TYPE_ENTITY_GROUP -> {
                 for (Environment env : Environment.values()) {
                     isb.setEntityGroupLimitsOffset(env, db.getTarget(),
                             isb.getEntityGroupLimitOffset(env, db.getTarget()) + amount);
@@ -124,8 +119,8 @@ public class LimitsReward extends Reward {
             List<RewardDB> rewards = tier.getRewards();
             rewards.add(dbObject);
             tier.setRewards(rewards);
-        } else if (saved instanceof LimitsRewardDB) {
-            dbObject = (LimitsRewardDB) saved;
+        } else if (saved instanceof LimitsRewardDB limitsRewardDB) {
+            dbObject = limitsRewardDB;
         } else {
             throw new InvalidParameterException("DB object in LimitsReward which is not a LimitsRewardDB");
         }
@@ -188,9 +183,9 @@ public class LimitsReward extends Reward {
         private PanelItem.ClickHandler onCycleType() {
             return (panel, client, click, slot) -> {
                 switch (this.saved.getLimitType()) {
-                    case "BLOCK" -> this.saved.setLimitType("ENTITY");
-                    case "ENTITY" -> this.saved.setLimitType("ENTITY_GROUP");
-                    default -> this.saved.setLimitType("BLOCK");
+                    case TYPE_BLOCK -> this.saved.setLimitType(TYPE_ENTITY);
+                    case TYPE_ENTITY -> this.saved.setLimitType(TYPE_ENTITY_GROUP);
+                    default -> this.saved.setLimitType(TYPE_BLOCK);
                 }
                 this.getAddon().getUpgradeDataManager().saveUpgradeTier(this.tier);
                 this.createInterface();

--- a/src/main/java/world/bentobox/upgrades/dataobjects/rewards/RangeReward.java
+++ b/src/main/java/world/bentobox/upgrades/dataobjects/rewards/RangeReward.java
@@ -1,6 +1,5 @@
 package world.bentobox.upgrades.dataobjects.rewards;
 
-import com.google.gson.annotations.Expose;
 import org.bukkit.Material;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
@@ -12,13 +11,13 @@ import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.database.objects.Island;
 import world.bentobox.upgrades.UpgradesAddon;
 import world.bentobox.upgrades.config.Settings;
+import world.bentobox.upgrades.dataobjects.FormulaVariables;
 import world.bentobox.upgrades.dataobjects.UpgradeTier;
 import world.bentobox.upgrades.ui.utils.AbPanel;
 
 import java.security.InvalidParameterException;
 import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
 import java.util.function.Consumer;
 
 public class RangeReward extends Reward {
@@ -58,10 +57,7 @@ public class RangeReward extends Reward {
     @Override
     public void apply(UpgradesAddon addon, User user, Island island, RewardDB rewardDB, int currentLevel) {
         RangeRewardDB db = (RangeRewardDB) rewardDB;
-        Map<String, Double> variables = new TreeMap<>();
-        variables.put(LEVEL_VAR, (double) currentLevel);
-        variables.put(ISLAND_LEVEL_VAR, (double) addon.getUpgradesManager().getIslandLevel(island));
-        variables.put(NUMBER_PLAYER_VAR, (double) island.getMemberSet().size());
+        Map<String, Double> variables = FormulaVariables.of(addon, island, currentLevel);
         int amount = (int) Settings.evaluate(db.getRangeUpgradeEquation(), variables);
 
         int newRange = island.getProtectionRange() + amount;
@@ -91,8 +87,8 @@ public class RangeReward extends Reward {
 
             rewards.add(dbObject);
             tier.setRewards(rewards);
-        } else if (saved instanceof RangeRewardDB) {
-            dbObject = (RangeRewardDB) saved;
+        } else if (saved instanceof RangeRewardDB rangeRewardDB) {
+            dbObject = rangeRewardDB;
         } else {
             throw new InvalidParameterException(
                     "DB object in RangeReward which is not an RangeRewardDB");
@@ -156,10 +152,7 @@ public class RangeReward extends Reward {
                                 input -> {
                                     // Validate that input is a parseable math expression (#70 item 8)
                                     try {
-                                        Map<String, Double> vars = new TreeMap<>();
-                                        vars.put(LEVEL_VAR, 1.0);
-                                        vars.put(ISLAND_LEVEL_VAR, 1.0);
-                                        vars.put(NUMBER_PLAYER_VAR, 1.0);
+                                        Map<String, Double> vars = FormulaVariables.of(1, 1, 1);
                                         Settings.evaluate(input, vars);
                                         return true;
                                     } catch (Exception e) {
@@ -175,7 +168,7 @@ public class RangeReward extends Reward {
         }
 
         private Consumer<String> doSetRule() {
-            return (rule) -> {
+            return rule -> {
                 this.saved.setRangeUpgradeEquation(rule);
                 this.getAddon().getUpgradeDataManager().saveUpgradeTier(this.tier);
                 this.createInterface();

--- a/src/main/java/world/bentobox/upgrades/dataobjects/rewards/Reward.java
+++ b/src/main/java/world/bentobox/upgrades/dataobjects/rewards/Reward.java
@@ -6,6 +6,7 @@ import world.bentobox.bentobox.api.addons.GameModeAddon;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.database.objects.Island;
 import world.bentobox.upgrades.UpgradesAddon;
+import world.bentobox.upgrades.dataobjects.FormulaVariables;
 import world.bentobox.upgrades.dataobjects.UpgradeTier;
 import world.bentobox.upgrades.ui.PanelAdminItem;
 import world.bentobox.upgrades.ui.PanelPublicItem;
@@ -13,14 +14,14 @@ import world.bentobox.upgrades.ui.utils.AbPanel;
 
 public abstract class Reward implements PanelAdminItem, PanelPublicItem {
 
-    public static final String LEVEL_VAR = "[level]";
-    public static final String ISLAND_LEVEL_VAR = "[islandLevel]";
-    public static final String NUMBER_PLAYER_VAR = "[numberPlayer]";
+    public static final String LEVEL_VAR = FormulaVariables.LEVEL_VAR;
+    public static final String ISLAND_LEVEL_VAR = FormulaVariables.ISLAND_LEVEL_VAR;
+    public static final String NUMBER_PLAYER_VAR = FormulaVariables.NUMBER_PLAYER_VAR;
 
     private final String name;
     private final Material icon;
 
-    public Reward(String name, Material icon) {
+    protected Reward(String name, Material icon) {
         this.name = name;
         this.icon = icon;
     }

--- a/src/main/java/world/bentobox/upgrades/dataobjects/rewards/RewardDB.java
+++ b/src/main/java/world/bentobox/upgrades/dataobjects/rewards/RewardDB.java
@@ -1,12 +1,10 @@
 package world.bentobox.upgrades.dataobjects.rewards;
 
-import com.google.gson.annotations.Expose;
-import world.bentobox.bentobox.database.objects.DataObject;
 
 public abstract class RewardDB {
 
-    abstract public Class<? extends Reward> getRewardType();
+    public abstract Class<? extends Reward> getRewardType();
 
-    abstract public boolean isValid();
+    public abstract boolean isValid();
 
 }

--- a/src/main/java/world/bentobox/upgrades/dataobjects/rewards/SpawnerReward.java
+++ b/src/main/java/world/bentobox/upgrades/dataobjects/rewards/SpawnerReward.java
@@ -10,13 +10,13 @@ import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.database.objects.Island;
 import world.bentobox.upgrades.UpgradesAddon;
 import world.bentobox.upgrades.config.Settings;
+import world.bentobox.upgrades.dataobjects.FormulaVariables;
 import world.bentobox.upgrades.dataobjects.UpgradeTier;
 import world.bentobox.upgrades.ui.utils.AbPanel;
 
 import java.security.InvalidParameterException;
 import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
 import java.util.function.Consumer;
 
 public class SpawnerReward extends Reward {
@@ -67,8 +67,8 @@ public class SpawnerReward extends Reward {
             List<RewardDB> rewards = tier.getRewards();
             rewards.add(dbObject);
             tier.setRewards(rewards);
-        } else if (saved instanceof SpawnerRewardDB) {
-            dbObject = (SpawnerRewardDB) saved;
+        } else if (saved instanceof SpawnerRewardDB spawnerRewardDB) {
+            dbObject = spawnerRewardDB;
         } else {
             throw new InvalidParameterException(
                     "DB object in SpawnerReward which is not a SpawnerRewardDB");
@@ -130,10 +130,7 @@ public class SpawnerReward extends Reward {
                         .askOneInput(this.doSetRule(),
                                 input -> {
                                     try {
-                                        Map<String, Double> vars = new TreeMap<>();
-                                        vars.put(LEVEL_VAR, 1.0);
-                                        vars.put(ISLAND_LEVEL_VAR, 1.0);
-                                        vars.put(NUMBER_PLAYER_VAR, 1.0);
+                                        Map<String, Double> vars = FormulaVariables.of(1, 1, 1);
                                         Settings.evaluate(input, vars);
                                         return true;
                                     } catch (Exception e) {
@@ -149,7 +146,7 @@ public class SpawnerReward extends Reward {
         }
 
         private Consumer<String> doSetRule() {
-            return (rule) -> {
+            return rule -> {
                 this.saved.setSpawnBonusEquation(rule);
                 this.getAddon().getUpgradeDataManager().saveUpgradeTier(this.tier);
                 this.createInterface();

--- a/src/main/java/world/bentobox/upgrades/listeners/BonusCalculator.java
+++ b/src/main/java/world/bentobox/upgrades/listeners/BonusCalculator.java
@@ -2,16 +2,15 @@ package world.bentobox.upgrades.listeners;
 
 import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
 import java.util.function.Function;
 
 import world.bentobox.bentobox.database.objects.Island;
 import world.bentobox.upgrades.UpgradesAddon;
 import world.bentobox.upgrades.api.UpgradeAPI;
 import world.bentobox.upgrades.config.Settings;
+import world.bentobox.upgrades.dataobjects.FormulaVariables;
 import world.bentobox.upgrades.dataobjects.UpgradeTier;
 import world.bentobox.upgrades.dataobjects.UpgradesData;
-import world.bentobox.upgrades.dataobjects.rewards.Reward;
 import world.bentobox.upgrades.dataobjects.rewards.RewardDB;
 import world.bentobox.upgrades.upgrades.DatabaseUpgrade;
 
@@ -27,22 +26,25 @@ final class BonusCalculator {
     static <R extends RewardDB> double sum(UpgradesAddon addon, Island island,
                                            Class<R> rewardType,
                                            Function<R, String> equationExtractor) {
+        if (island == null) {
+            return 0.0;
+        }
+
         double total = 0.0;
         long islandLevel = addon.getUpgradesManager().getIslandLevel(island);
         int memberCount = island.getMemberSet().size();
         UpgradesData data = addon.getUpgradesLevels(island.getUniqueId());
 
         for (UpgradeAPI upgradeAPI : addon.getAvailableUpgrades()) {
-            if (!(upgradeAPI instanceof DatabaseUpgrade dbUpgrade)) continue;
-
-            int currentLevel = data.getUpgradeLevel(dbUpgrade.getName());
-            if (currentLevel <= 0) continue;
-
-            UpgradeTier activeTier = findActiveTier(addon, dbUpgrade, currentLevel);
-            if (activeTier == null) continue;
-
-            total += sumTierRewards(activeTier, rewardType, equationExtractor,
-                    currentLevel, islandLevel, memberCount);
+            if (upgradeAPI instanceof DatabaseUpgrade dbUpgrade) {
+                int currentLevel = data.getUpgradeLevel(dbUpgrade.getName());
+                UpgradeTier activeTier = currentLevel <= 0 ? null
+                        : findActiveTier(addon, dbUpgrade, currentLevel);
+                if (activeTier != null) {
+                    total += sumTierRewards(activeTier, rewardType, equationExtractor,
+                            currentLevel, islandLevel, memberCount);
+                }
+            }
         }
         return total;
     }
@@ -63,10 +65,7 @@ final class BonusCalculator {
                                                               Function<R, String> equationExtractor,
                                                               int currentLevel, long islandLevel,
                                                               int memberCount) {
-        Map<String, Double> vars = new TreeMap<>();
-        vars.put(Reward.LEVEL_VAR, (double) currentLevel);
-        vars.put(Reward.ISLAND_LEVEL_VAR, (double) islandLevel);
-        vars.put(Reward.NUMBER_PLAYER_VAR, (double) memberCount);
+        Map<String, Double> vars = FormulaVariables.of(currentLevel, islandLevel, memberCount);
 
         double subtotal = 0.0;
         for (RewardDB rewardDB : tier.getRewards()) {

--- a/src/main/java/world/bentobox/upgrades/listeners/LimitsPermCheckListener.java
+++ b/src/main/java/world/bentobox/upgrades/listeners/LimitsPermCheckListener.java
@@ -10,7 +10,6 @@ import org.bukkit.event.Listener;
 import world.bentobox.limits.EntityGroup;
 import world.bentobox.limits.events.LimitsPermCheckEvent;
 import world.bentobox.upgrades.UpgradesAddon;
-import world.bentobox.upgrades.UpgradesManager;
 
 /**
  * Checks perms of players if Limits changes something
@@ -35,24 +34,18 @@ public class LimitsPermCheckListener implements Listener {
 		World world = e.getPlayer().getWorld();
 
         // Cancel the event if this block is handled by Upgrades
-		if (block != null) {
-			if (this.addon.getUpgradesManager().getAllBlockLimitsUpgradeTiers(world).containsKey(block)) {
-				e.setCancelled(true);
-			}
+		if (block != null && this.addon.getUpgradesManager().getAllBlockLimitsUpgradeTiers(world).containsKey(block)) {
+			e.setCancelled(true);
 		}
 
         // Cancel the event if this entity is being covered by Upgrades
-		if (et != null) {
-			if (this.addon.getUpgradesManager().getAllEntityLimitsUpgradeTiers(world).containsKey(et)) {
-				e.setCancelled(true);
-			}
+		if (et != null && this.addon.getUpgradesManager().getAllEntityLimitsUpgradeTiers(world).containsKey(et)) {
+			e.setCancelled(true);
 		}
 
         // Cancel if this Entity Group is handled by Upgrades
-		if (entgroup != null) {
-			if (this.addon.getUpgradesManager().getAllEntityGroupLimitsUpgradeTiers(world).containsKey(entgroup.getName())) {
-				e.setCancelled(true);
-			}
+		if (entgroup != null && this.addon.getUpgradesManager().getAllEntityGroupLimitsUpgradeTiers(world).containsKey(entgroup.getName())) {
+			e.setCancelled(true);
 		}
 	}
 

--- a/src/main/java/world/bentobox/upgrades/ui/Panel.java
+++ b/src/main/java/world/bentobox/upgrades/ui/Panel.java
@@ -3,7 +3,7 @@ package world.bentobox.upgrades.ui;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Set;
 
 import world.bentobox.bentobox.api.panels.PanelItem;
 import world.bentobox.bentobox.api.panels.builders.PanelItemBuilder;
@@ -20,6 +20,7 @@ import world.bentobox.upgrades.api.UpgradeAPI;
  */
 public class Panel {
 
+    private static final String UPGRADE = "UPGRADE";
     private final UpgradesAddon addon;
     private final Island island;
     private int page;
@@ -41,22 +42,26 @@ public class Panel {
      * @param user user
      */
     public void showPanel(User user) {
-        List<UpgradeAPI> visible = addon.getAvailableUpgrades().stream()
-                .peek(u -> u.updateUpgradeValue(user, island))
+        // Every registered upgrade refreshes its cached values on each panel open,
+        // including the ones that end up hidden.
+        Set<UpgradeAPI> upgrades = addon.getAvailableUpgrades();
+        upgrades.forEach(u -> u.updateUpgradeValue(user, island));
+
+        List<UpgradeAPI> visible = upgrades.stream()
                 .filter(u -> u.isShowed(user, island))
-                .collect(Collectors.toList());
+                .toList();
 
         new TemplatedPanelBuilder()
                 .user(user)
                 .world(island.getWorld())
                 .template("upgrades_panel", new File(addon.getDataFolder(), "panels"))
-                .registerTypeBuilder("UPGRADE", (t, s) -> createUpgradeButton(t, s, user, visible))
-                .registerTypeBuilder("NEXT", (t, s) -> createNextButton(t, s, user, visible))
-                .registerTypeBuilder("PREVIOUS", (t, s) -> createPreviousButton(t, s, user))
+                .registerTypeBuilder(UPGRADE, (t, s) -> createUpgradeButton(s, user, visible))
+                .registerTypeBuilder("NEXT", (t, s) -> createNextButton(t, s, visible))
+                .registerTypeBuilder("PREVIOUS", (t, s) -> createPreviousButton(t))
                 .build();
     }
 
-    private PanelItem createUpgradeButton(ItemTemplateRecord template, TemplatedPanel.ItemSlot slot,
+    private PanelItem createUpgradeButton(TemplatedPanel.ItemSlot slot,
             User user, List<UpgradeAPI> visible) {
         int upgradesPerPage = slot.amount("UPGRADE");
         int index = slot.slot() + page * upgradesPerPage;
@@ -89,7 +94,7 @@ public class Panel {
     }
 
     private PanelItem createNextButton(ItemTemplateRecord template, TemplatedPanel.ItemSlot slot,
-            User user, List<UpgradeAPI> visible) {
+            List<UpgradeAPI> visible) {
         if ((page + 1) * slot.amount("UPGRADE") >= visible.size()) {
             return null;
         }
@@ -106,8 +111,7 @@ public class Panel {
                 .build();
     }
 
-    private PanelItem createPreviousButton(ItemTemplateRecord template, TemplatedPanel.ItemSlot slot,
-            User user) {
+    private PanelItem createPreviousButton(ItemTemplateRecord template) {
         if (page == 0) {
             return null;
         }

--- a/src/main/java/world/bentobox/upgrades/ui/PanelAdminItem.java
+++ b/src/main/java/world/bentobox/upgrades/ui/PanelAdminItem.java
@@ -6,11 +6,11 @@ import world.bentobox.bentobox.api.user.User;
 
 public interface PanelAdminItem {
 
-	abstract public Material getIcon();
+	public abstract Material getIcon();
 
-	abstract public String getName();
+	public abstract String getName();
 
-	abstract public String getAdminName(User user);
+	public abstract String getAdminName(User user);
 
-	abstract public String getAdminDescription(User user);
+	public abstract String getAdminDescription(User user);
 }

--- a/src/main/java/world/bentobox/upgrades/ui/PanelPublicItem.java
+++ b/src/main/java/world/bentobox/upgrades/ui/PanelPublicItem.java
@@ -5,11 +5,11 @@ import org.bukkit.Material;
 import world.bentobox.bentobox.api.user.User;
 
 public interface PanelPublicItem {
-	abstract public Material getIcon();
+	public abstract Material getIcon();
 
-	abstract public String getName();
+	public abstract String getName();
 
-	abstract public String getPublicName(User user);
+	public abstract String getPublicName(User user);
 
-	abstract public String getPublicDescription(User user);
+	public abstract String getPublicDescription(User user);
 }

--- a/src/main/java/world/bentobox/upgrades/ui/admin/AdminList.java
+++ b/src/main/java/world/bentobox/upgrades/ui/admin/AdminList.java
@@ -18,17 +18,17 @@ import world.bentobox.upgrades.UpgradesAddon;
 import world.bentobox.upgrades.ui.PanelAdminItem;
 import world.bentobox.upgrades.ui.utils.AbPanel;
 
-public final class AdminList<Item extends PanelAdminItem> extends AbPanel {
+public final class AdminList<T extends PanelAdminItem> extends AbPanel {
 
     private static final String CREATE = "create";
 
     @NonNull
-    private final List<Item> items;
+    private final List<T> items;
 
     @Nullable
-    private final Consumer<Item> onLeftClick;
+    private final Consumer<T> onLeftClick;
     @Nullable
-    private final Consumer<Item> onRightClick;
+    private final Consumer<T> onRightClick;
     @Nullable
     private Runnable createButton;
 
@@ -41,8 +41,8 @@ public final class AdminList<Item extends PanelAdminItem> extends AbPanel {
 
     public AdminList(UpgradesAddon addon, GameModeAddon gamemode, User user, String title,
                      AbPanel parent,
-                     @NonNull List<Item> items, @Nullable Consumer<Item> onLeftClick,
-                     @Nullable Consumer<Item> onRightClick, @Nullable Runnable createButton,
+                     @NonNull List<T> items, @Nullable Consumer<T> onLeftClick,
+                     @Nullable Consumer<T> onRightClick, @Nullable Runnable createButton,
                      @Nullable String createName, @Nullable String leftClickDesc,
                      @Nullable String rightClickDesc) {
         super(addon, gamemode, user, title, parent);
@@ -72,7 +72,7 @@ public final class AdminList<Item extends PanelAdminItem> extends AbPanel {
 
         IntStream.range(0, this.items.size())
                 .forEach(idx -> {
-                    Item item = this.items.get(idx);
+                    T item = this.items.get(idx);
                     int pos = ((idx / 7) * 9) + (idx % 7) + 10;
                     List<String> desc = new ArrayList<>();
 
@@ -98,7 +98,7 @@ public final class AdminList<Item extends PanelAdminItem> extends AbPanel {
         return true;
     };
 
-    private ClickHandler onClickItem(Item item) {
+    private ClickHandler onClickItem(T item) {
         return (panel, client, click, slot) -> {
             if (click.isLeftClick() && this.onLeftClick != null) {
                 this.onLeftClick.accept(item);

--- a/src/main/java/world/bentobox/upgrades/ui/admin/AdminPanel.java
+++ b/src/main/java/world/bentobox/upgrades/ui/admin/AdminPanel.java
@@ -134,7 +134,7 @@ public class AdminPanel extends AbPanel {
 						client.getTranslation("upgrades.ui.titles.delete",
 								"[name]", upgrade.getName()),
 						this, delete -> {
-							if (delete) {
+							if (Boolean.TRUE.equals(delete)) {
 								this.getAddon().getUpgradeDataManager().deleteUpgradeData(upgrade);
 								this.getAddon().refreshDatabaseUpgrades();
 							}

--- a/src/main/java/world/bentobox/upgrades/ui/admin/EditTierPanel.java
+++ b/src/main/java/world/bentobox/upgrades/ui/admin/EditTierPanel.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
@@ -143,7 +142,7 @@ public final class EditTierPanel extends AbPanel {
         this.getAddon().getUpgradeDataManager().saveUpgradeTier(this.tier);
     }
 
-    private final Consumer<String> doSetName = (name) -> {
+    private final Consumer<String> doSetName = name -> {
         applySetName(name);
         this.setButton();
         this.getBuild()
@@ -170,7 +169,7 @@ public final class EditTierPanel extends AbPanel {
         this.getAddon().getUpgradeDataManager().saveUpgradeTier(this.tier);
     }
 
-    private final Consumer<List<String>> doSetDescription = (description) -> {
+    private final Consumer<List<String>> doSetDescription = description -> {
         applySetDescription(description);
         if (description != null) {
             this.setButton();
@@ -255,7 +254,7 @@ public final class EditTierPanel extends AbPanel {
                                 .getUpgradesManager()
                                 .searchPrice(p.getPriceType())
                 )
-                .collect(Collectors.toList());
+                .toList();
 
         new AdminList<>(this.getAddon(), this.getGamemode(), client,
                 title, this, prices,
@@ -277,7 +276,7 @@ public final class EditTierPanel extends AbPanel {
                                 .getUpgradesManager()
                                 .searchReward(reward.getRewardType())
                 )
-                .collect(Collectors.toList());
+                .toList();
 
         new AdminList<>(this.getAddon(), this.getGamemode(), client, title, this, rewards,
                 this.onSelectReward, this.onDeleteReward,
@@ -286,10 +285,10 @@ public final class EditTierPanel extends AbPanel {
         return true;
     };
 
-    private final Consumer<Price> onSelectPrice = (price) -> {
+    private final Consumer<Price> onSelectPrice = price -> {
         PriceDB selected = this.tier.getPrices()
                 .stream()
-                .filter((p) -> p.getPriceType() == price.getClass())
+                .filter(p -> p.getPriceType() == price.getClass())
                 .findFirst()
                 .orElse(null);
 
@@ -299,10 +298,10 @@ public final class EditTierPanel extends AbPanel {
                 .build();
     };
 
-    private final Consumer<Reward> onSelectReward = (reward) -> {
+    private final Consumer<Reward> onSelectReward = reward -> {
         RewardDB selected = this.tier.getRewards()
                 .stream()
-                .filter((r) -> r.getRewardType() == reward.getClass())
+                .filter(r -> r.getRewardType() == reward.getClass())
                 .findFirst()
                 .orElse(null);
 
@@ -312,16 +311,14 @@ public final class EditTierPanel extends AbPanel {
                 .build();
     };
 
-    private final Consumer<Price> onDeletePrice = (price) ->
+    private final Consumer<Price> onDeletePrice = price ->
             new YesNoPanel(this.getAddon(), this.getGamemode(), this.getUser(),
                     this.getUser()
                             .getTranslation("upgrades.ui.titles.delete"), this, delete -> {
-                if (delete) {
-                    List<PriceDB> prices = this.tier.getPrices();
-                    prices = prices.stream()
-                            .filter(p -> p.getPriceType() != price.getClass())
-                            .collect(
-                                    Collectors.toList());
+                if (Boolean.TRUE.equals(delete)) {
+                    // Must stay mutable: prices are later appended to when a price is added
+                    List<PriceDB> prices = new ArrayList<>(this.tier.getPrices());
+                    prices.removeIf(p -> p.getPriceType() == price.getClass());
                     this.tier.setPrices(prices);
                     this.getAddon().getUpgradeDataManager().saveUpgradeTier(this.tier);
                 }
@@ -329,15 +326,13 @@ public final class EditTierPanel extends AbPanel {
                         .build();
             }).getBuild().build();
 
-    private final Consumer<Reward> onDeleteReward = (reward) ->
+    private final Consumer<Reward> onDeleteReward = reward ->
             new YesNoPanel(this.getAddon(), this.getGamemode(), this.getUser(), this.getUser()
                     .getTranslation("upgrades.ui.titles.delete"), this, delete -> {
-                if (delete) {
-                    List<RewardDB> rewards = this.tier.getRewards();
-                    rewards = rewards.stream()
-                            .filter(r -> r.getRewardType() != reward.getClass())
-                            .collect(
-                                    Collectors.toList());
+                if (Boolean.TRUE.equals(delete)) {
+                    // Must stay mutable: rewards are later appended to when a reward is added
+                    List<RewardDB> rewards = new ArrayList<>(this.tier.getRewards());
+                    rewards.removeIf(r -> r.getRewardType() == reward.getClass());
                     this.tier.setRewards(rewards);
                     this.getAddon().getUpgradeDataManager().saveUpgradeTier(this.tier);
                 }
@@ -370,13 +365,13 @@ public final class EditTierPanel extends AbPanel {
                 .build();
     };
 
-    private final Consumer<Price> onSelectNewPrice = (price) ->
+    private final Consumer<Price> onSelectNewPrice = price ->
             price.getAdminPanel(this.getAddon(), this.getGamemode(), this.getUser(), this, this.tier,
                             null)
                     .getBuild()
                     .build();
 
-    private final Consumer<Reward> onSelectNewReward = (reward) ->
+    private final Consumer<Reward> onSelectNewReward = reward ->
             reward.getAdminPanel(this.getAddon(), this.getGamemode(), this.getUser(), this, this.tier,
                             null)
                     .getBuild()
@@ -385,8 +380,8 @@ public final class EditTierPanel extends AbPanel {
     private List<Integer> computeTierLength(List<UpgradeTier> tiers) {
         List<Integer> lengths = new ArrayList<>();
 
-        tiers.forEach(tier ->
-                lengths.add(tier.getEndLevel() - tier.getStartLevel() + 1)
+        tiers.forEach(t ->
+                lengths.add(t.getEndLevel() - t.getStartLevel() + 1)
         );
 
         return lengths;

--- a/src/main/java/world/bentobox/upgrades/ui/admin/EditUpgradePanel.java
+++ b/src/main/java/world/bentobox/upgrades/ui/admin/EditUpgradePanel.java
@@ -134,7 +134,7 @@ public class EditUpgradePanel extends AbPanel {
 		this.getAddon().getUpgradeDataManager().saveUpgradeData(this.upgrade);
 	}
 
-	private Consumer<String> doSetName = (name) -> {
+	private Consumer<String> doSetName = name -> {
 		applySetName(name);
 		this.setButton();
 		this.getBuild().build();
@@ -156,7 +156,7 @@ public class EditUpgradePanel extends AbPanel {
 		this.getAddon().getUpgradeDataManager().saveUpgradeData(this.upgrade);
 	}
 
-	private Consumer<List<String>> doSetDescription = (descrip) -> {
+	private Consumer<List<String>> doSetDescription = descrip -> {
 		applySetDescription(descrip);
 		if (descrip != null) {
 			this.setButton();
@@ -194,7 +194,7 @@ public class EditUpgradePanel extends AbPanel {
 	private Consumer<String> doTierAdd = input -> {
 		String uniqueId = this.getGamemode().getDescription().getName() + "_" + input;
 		List<UpgradeTier> tiers = this.getAddon().getUpgradeDataManager().getUpgradeTierByUpgradeData(this.upgrade);
-		int lastpos = tiers.size() > 0 ? tiers.get(tiers.size() - 1).getEndLevel() + 1 : 0;
+		int lastpos = !tiers.isEmpty() ? tiers.get(tiers.size() - 1).getEndLevel() + 1 : 0;
 
 		UpgradeTier newTier = this.getAddon().getUpgradeDataManager()
 				.createUpgradeTier(uniqueId, this.upgrade, lastpos, lastpos, this.getUser());
@@ -221,13 +221,11 @@ public class EditUpgradePanel extends AbPanel {
 				this.getGamemode(), client, this.upgrade,
 				client.getTranslation("upgrades.ui.titles.editlist"),
 				this,
-				tier -> {
-					new EditTierPanel(this.getAddon(),
+				tier -> new EditTierPanel(this.getAddon(),
 							this.getGamemode(), client, tier,
 							this.getAddon().getUpgradeDataManager().getUpgradeTierByUpgradeData(this.upgrade),
 							this)
-						.getBuild().build();
-				})
+						.getBuild().build())
 			.getBuild().build();
 		return true;
 	};
@@ -241,18 +239,16 @@ public class EditUpgradePanel extends AbPanel {
 		return true;
 	};
 	
-	private Consumer<UpgradeTier> doTierDelete = tier -> {
-		new YesNoPanel(this.getAddon(),
-				this.getGamemode(), this.getUser(),
-				this.getUser().getTranslation("upgrades.ui.titles.delete",
-						"[name]", tier.getUniqueId()),
-				this, delete -> {
-					if (delete) {
-						this.getAddon().getUpgradeDataManager().deleteUpgradeTier(tier);
-					}
-					this.getBuild().build();
-				}).getBuild().build();
-	};
+	private Consumer<UpgradeTier> doTierDelete = tier -> new YesNoPanel(this.getAddon(),
+			this.getGamemode(), this.getUser(),
+			this.getUser().getTranslation("upgrades.ui.titles.delete",
+					"[name]", tier.getUniqueId()),
+			this, delete -> {
+				if (Boolean.TRUE.equals(delete)) {
+					this.getAddon().getUpgradeDataManager().deleteUpgradeTier(tier);
+				}
+				this.getBuild().build();
+			}).getBuild().build();
 	
 	private ClickHandler onSetOrder = (panel, client, click, slot) -> {
 		this.getAddon().getChatInput().askOneNumber(this.doSetOrder,
@@ -268,7 +264,7 @@ public class EditUpgradePanel extends AbPanel {
 		this.getAddon().getUpgradeDataManager().saveUpgradeData(this.upgrade);
 	}
 
-	private Consumer<Number> doSetOrder = (order) -> {
+	private Consumer<Number> doSetOrder = order -> {
 		applySetOrder(order.intValue());
 		this.setButton();
 		this.getBuild().build();

--- a/src/main/java/world/bentobox/upgrades/ui/utils/AbPanel.java
+++ b/src/main/java/world/bentobox/upgrades/ui/utils/AbPanel.java
@@ -8,7 +8,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.bukkit.Material;
 
@@ -78,7 +77,9 @@ public class AbPanel {
 	 * Hook called at the start of getBuild() before building the panel.
 	 * Override in subclasses to refresh panel content dynamically.
 	 */
-	protected void onBuildHook() {}
+	protected void onBuildHook() {
+		// Intentionally empty; subclasses override to add custom logic
+	}
 	
 	/**
 	 * Clears all named panel items (but not the border).
@@ -95,13 +96,9 @@ public class AbPanel {
 		builder.user(this.user);
 		builder.name(this.title);
 		
-		this.border.forEach((PanelSlot item) -> {
-			builder.item(item.getSlot(), item.getItem());
-		});
-		
-		this.items.forEach((String name, PanelSlot item) -> {
-			builder.item(item.getSlot(), item.getItem());
-		});
+		this.border.forEach((PanelSlot item) -> builder.item(item.getSlot(), item.getItem()));
+
+		this.items.forEach((String name, PanelSlot item) -> builder.item(item.getSlot(), item.getItem()));
 		
 		return builder;
 	}
@@ -184,7 +181,7 @@ public class AbPanel {
 		List<String> lines = new ArrayList<>();
 		StringBuilder current = new StringBuilder();
 		for (String word : text.split(" ")) {
-			if (current.length() == 0) {
+			if (current.isEmpty()) {
 				current.append(word);
 			} else if (current.length() + 1 + word.length() <= maxWidth) {
 				current.append(' ').append(word);
@@ -193,7 +190,7 @@ public class AbPanel {
 				current = new StringBuilder(word);
 			}
 		}
-		if (current.length() > 0) lines.add(current.toString());
+		if (!current.isEmpty()) lines.add(current.toString());
 		return lines;
 	}
 
@@ -208,7 +205,7 @@ public class AbPanel {
 		if (lore == null) return Collections.emptyList();
 		return lore.stream()
 				.flatMap(line -> wrapText(line, LORE_MAX_WIDTH).stream())
-				.collect(Collectors.toList());
+				.toList();
 	}
 
 	protected void setItems(String name, PanelItem item, int slot) {

--- a/src/main/java/world/bentobox/upgrades/ui/utils/ChatInput.java
+++ b/src/main/java/world/bentobox/upgrades/ui/utils/ChatInput.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.function.Consumer;
-import java.util.function.Function;
 
 import org.bukkit.conversations.Conversation;
 import org.bukkit.conversations.ConversationContext;
@@ -56,7 +55,7 @@ public class ChatInput {
 	 * @param invalidText Showed to the user when it's input is invalid
 	 * @param user User to converse with
 	 */
-	public void askOneInput(Consumer<String> consumer, Function<String, Boolean> validation, String question, String invalidText, User user, boolean sanitize) {
+	public void askOneInput(Consumer<String> consumer, java.util.function.Predicate<String> validation, String question, String invalidText, User user, boolean sanitize) {
 		// Track whether the consumer was already called with valid input
 		final boolean[] consumerCalled = {false};
 		// Create conversation
@@ -88,7 +87,7 @@ public class ChatInput {
 						input = sanitizeInput(input);
 					}
 					// Check if input is valid
-					return validation.apply(input);
+					return validation.test(input);
 				}
 				
 				@Override
@@ -115,14 +114,11 @@ public class ChatInput {
 		conv.begin();
 	}
 	
-	public void askMultiLine(Consumer<List<String>> consumer, Function<String, Boolean> validation, String question, String invalidText, User user) {
+	public void askMultiLine(Consumer<List<String>> consumer, java.util.function.Predicate<String> validation, String question, String invalidText, User user) {
 		List<String> list = new ArrayList<String>();
-		UpgradesAddon addon = this.addon;
-		Conversation conv = new ConversationFactory(addon.getPlugin())
-			.withEscapeSequence(addon.getSettings().getChatInputEscape())
-			.addConversationAbandonedListener(abandoned -> {
-				consumer.accept(list);
-			})
+		Conversation conv = new ConversationFactory(this.addon.getPlugin())
+			.withEscapeSequence(this.addon.getSettings().getChatInputEscape())
+			.addConversationAbandonedListener(abandoned -> consumer.accept(list))
 			.withFirstPrompt(new ValidatingPrompt() {
 				
 				boolean sayMessage = true;
@@ -137,7 +133,7 @@ public class ChatInput {
 				
 				@Override
 				protected boolean isInputValid(ConversationContext context, String input) {
-					return validation.apply(input);
+					return validation.test(input);
 				}
 				
 				@Override
@@ -151,7 +147,7 @@ public class ChatInput {
 		conv.begin();
 	}
 	
-	public void askOneNumber(Consumer<Number> consumer, Function<Number, Boolean> validation, String question, String invalidText, User user) {
+	public void askOneNumber(Consumer<Number> consumer, java.util.function.Predicate<Number> validation, String question, String invalidText, User user) {
 		Conversation conv = new ConversationFactory(this.addon.getPlugin())
 			.withEscapeSequence(this.addon.getSettings().getChatInputEscape())
 			.addConversationAbandonedListener(abandoned -> {
@@ -172,7 +168,7 @@ public class ChatInput {
 				
 				@Override
 				protected boolean isNumberValid(ConversationContext context, Number input) {
-					return super.isNumberValid(context, input) && validation.apply(input);
+					return super.isNumberValid(context, input) && validation.test(input);
 				}
 				
 				@Override

--- a/src/main/java/world/bentobox/upgrades/upgrades/BlockLimitsUpgrade.java
+++ b/src/main/java/world/bentobox/upgrades/upgrades/BlockLimitsUpgrade.java
@@ -34,7 +34,7 @@ public class BlockLimitsUpgrade extends LimitsUpgrade {
                 upgradeLevel, islandLevel, numberPeople, island.getWorld());
         UpgradeValues upgrade;
 
-        if (upgradeInfos == null) {
+        if (upgradeInfos.isEmpty()) {
             upgrade = null;
             this.setOwnDescription(user, null);
         } else {
@@ -56,11 +56,11 @@ public class BlockLimitsUpgrade extends LimitsUpgrade {
         String newDisplayName;
 
         if (upgrade == null) {
-            newDisplayName = user.getTranslation("upgrades.ui.upgradepanel.nolimitsupgrade", BLOCK,
+            newDisplayName = user.getTranslation("upgrades.ui.upgradepanel.nolimitsupgrade", BLOCK_PLACEHOLDER,
                     this.block.toString());
         } else {
-            newDisplayName = user.getTranslation("upgrades.ui.upgradepanel.limitsupgrade", BLOCK,
-                    this.block.toString(), LEVEL, Integer.toString(upgrade.getUpgradeValue()));
+            newDisplayName = user.getTranslation("upgrades.ui.upgradepanel.limitsupgrade", BLOCK_PLACEHOLDER,
+                    this.block.toString(), LEVEL_PLACEHOLDER, Integer.toString(upgrade.getUpgradeValue()));
         }
 
         this.setDisplayName(newDisplayName);

--- a/src/main/java/world/bentobox/upgrades/upgrades/CommandUpgrade.java
+++ b/src/main/java/world/bentobox/upgrades/upgrades/CommandUpgrade.java
@@ -34,7 +34,7 @@ public class CommandUpgrade extends UpgradeAPI {
         Map<String, Integer> upgradeInfos = upgradesAddon.getUpgradesManager().getCommandUpgradeInfos(this.cmdId, upgradeLevel, islandLevel, numberPeople, island.getWorld());
         UpgradeValues upgrade;
 
-        if (upgradeInfos == null) {
+        if (upgradeInfos.isEmpty()) {
             upgrade = null;
             this.setOwnDescription(user, null);
         } else {

--- a/src/main/java/world/bentobox/upgrades/upgrades/EntityGroupLimitsUpgrade.java
+++ b/src/main/java/world/bentobox/upgrades/upgrades/EntityGroupLimitsUpgrade.java
@@ -50,7 +50,7 @@ public class EntityGroupLimitsUpgrade extends LimitsUpgrade {
         Map<String, Integer> upgradeInfos = upgradeAddon.getUpgradesManager().getEntityGroupLimitsUpgradeInfos(this.group, upgradeLevel, islandLevel, numberPeople, island.getWorld());
         UpgradeValues upgrade;
 
-        if (upgradeInfos == null) {
+        if (upgradeInfos.isEmpty()) {
             upgrade = null;
             this.setOwnDescription(user, null);
         } else {
@@ -72,10 +72,10 @@ public class EntityGroupLimitsUpgrade extends LimitsUpgrade {
 
         if (upgrade == null) {
             newDisplayName = user.getTranslation("upgrades.ui.upgradepanel.nolimitsupgrade",
-                    BLOCK, this.group);
+                    BLOCK_PLACEHOLDER, this.group);
         } else {
             newDisplayName = user.getTranslation("upgrades.ui.upgradepanel.limitsupgrade",
-                    BLOCK, this.group, LEVEL, Integer.toString(upgrade.getUpgradeValue()));
+                    BLOCK_PLACEHOLDER, this.group, LEVEL_PLACEHOLDER, Integer.toString(upgrade.getUpgradeValue()));
         }
 
         this.setDisplayName(newDisplayName);

--- a/src/main/java/world/bentobox/upgrades/upgrades/EntityLimitsUpgrade.java
+++ b/src/main/java/world/bentobox/upgrades/upgrades/EntityLimitsUpgrade.java
@@ -51,7 +51,7 @@ public class EntityLimitsUpgrade extends LimitsUpgrade {
                 upgradeLevel, islandLevel, numberPeople, island.getWorld());
         UpgradeValues upgrade;
 
-        if (upgradeInfos == null) {
+        if (upgradeInfos.isEmpty()) {
             upgrade = null;
             this.setOwnDescription(user, null);
         } else {
@@ -72,11 +72,11 @@ public class EntityLimitsUpgrade extends LimitsUpgrade {
         String newDisplayName;
 
         if (upgrade == null) {
-            newDisplayName = user.getTranslation("upgrades.ui.upgradepanel.nolimitsupgrade", BLOCK,
+            newDisplayName = user.getTranslation("upgrades.ui.upgradepanel.nolimitsupgrade", BLOCK_PLACEHOLDER,
                     this.entity.toString());
         } else {
-            newDisplayName = user.getTranslation("upgrades.ui.upgradepanel.limitsupgrade", BLOCK,
-                    this.entity.toString(), LEVEL, Integer.toString(upgrade.getUpgradeValue()));
+            newDisplayName = user.getTranslation("upgrades.ui.upgradepanel.limitsupgrade", BLOCK_PLACEHOLDER,
+                    this.entity.toString(), LEVEL_PLACEHOLDER, Integer.toString(upgrade.getUpgradeValue()));
         }
 
         this.setDisplayName(newDisplayName);

--- a/src/main/java/world/bentobox/upgrades/upgrades/LimitsUpgrade.java
+++ b/src/main/java/world/bentobox/upgrades/upgrades/LimitsUpgrade.java
@@ -22,8 +22,8 @@ import world.bentobox.upgrades.dataobjects.UpgradesData;
  */
 public abstract class LimitsUpgrade extends UpgradeAPI {
 
-    protected static final String BLOCK = "[block]";
-    protected static final String LEVEL = "[level]";
+    protected static final String BLOCK_PLACEHOLDER = "[block]";
+    protected static final String LEVEL_PLACEHOLDER = "[level]";
 
     protected LimitsUpgrade(UpgradesAddon addon, String name, String displayName, Material icon) {
         super(addon, name, displayName, icon);
@@ -146,7 +146,7 @@ public abstract class LimitsUpgrade extends UpgradeAPI {
             this.applyOffset(isb, env, amount);
         }
 
-        user.sendMessage("upgrades.ui.upgradepanel.limitsupgradedone", BLOCK, this.getTargetName(), LEVEL,
+        user.sendMessage("upgrades.ui.upgradepanel.limitsupgradedone", BLOCK_PLACEHOLDER, this.getTargetName(), LEVEL_PLACEHOLDER,
                 Integer.toString(amount));
 
         return true;

--- a/src/main/java/world/bentobox/upgrades/upgrades/RangeUpgrade.java
+++ b/src/main/java/world/bentobox/upgrades/upgrades/RangeUpgrade.java
@@ -66,7 +66,7 @@ public class RangeUpgrade extends UpgradeAPI {
         UpgradeValues upgrade;
 
         // If null -> no next upgrades
-        if (upgradeInfos == null) {
+        if (upgradeInfos.isEmpty()) {
             upgrade = null;
             this.setOwnDescription(user, null);
         } else {

--- a/src/test/java/world/bentobox/upgrades/DefaultUpgradeSeederTest.java
+++ b/src/test/java/world/bentobox/upgrades/DefaultUpgradeSeederTest.java
@@ -5,8 +5,6 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -27,13 +25,10 @@ import world.bentobox.upgrades.dataobjects.prices.IslandLevelPriceDB;
 import world.bentobox.upgrades.dataobjects.prices.ItemPriceDB;
 import world.bentobox.upgrades.dataobjects.prices.MoneyPriceDB;
 import world.bentobox.upgrades.dataobjects.prices.PermissionPriceDB;
-import world.bentobox.upgrades.dataobjects.prices.PriceDB;
 import world.bentobox.upgrades.dataobjects.rewards.CommandRewardDB;
 import world.bentobox.upgrades.dataobjects.rewards.CropGrowthRewardDB;
 import world.bentobox.upgrades.dataobjects.rewards.LimitsRewardDB;
 import world.bentobox.upgrades.dataobjects.rewards.RangeRewardDB;
-import world.bentobox.upgrades.dataobjects.rewards.RewardDB;
-import world.bentobox.upgrades.dataobjects.rewards.SpawnerRewardDB;
 
 /**
  * Verifies that DefaultUpgradeSeeder correctly persists all upgrade definitions
@@ -105,7 +100,7 @@ class DefaultUpgradeSeederTest {
 
         List<String> names = captor.getAllValues().stream()
                 .map(UpgradeData::getName)
-                .collect(Collectors.toList());
+                .toList();
         assertTrue(names.contains("Border Expansion I"));
         assertTrue(names.contains("Border Expansion II"));
         assertTrue(names.contains("Hopper Limit"));
@@ -158,16 +153,16 @@ class DefaultUpgradeSeederTest {
         UpgradeTier tier = capturedTierFor("BSkyBlock_example_range1_t1");
         assertNotNull(tier, "Tier for Border Expansion I must be saved");
 
-        assertTrue(tier.getPrices().stream().anyMatch(p -> p instanceof MoneyPriceDB),
+        assertTrue(tier.getPrices().stream().anyMatch(MoneyPriceDB.class::isInstance),
                 "Border Expansion I must have a MoneyPrice");
         MoneyPriceDB money = (MoneyPriceDB) tier.getPrices().stream()
-                .filter(p -> p instanceof MoneyPriceDB).findFirst().orElseThrow();
+                .filter(MoneyPriceDB.class::isInstance).findFirst().orElseThrow();
         assertEquals("500", money.getAmountEquation());
 
-        assertTrue(tier.getRewards().stream().anyMatch(r -> r instanceof RangeRewardDB),
+        assertTrue(tier.getRewards().stream().anyMatch(RangeRewardDB.class::isInstance),
                 "Border Expansion I must have a RangeReward");
         RangeRewardDB range = (RangeRewardDB) tier.getRewards().stream()
-                .filter(r -> r instanceof RangeRewardDB).findFirst().orElseThrow();
+                .filter(RangeRewardDB.class::isInstance).findFirst().orElseThrow();
         assertEquals("5", range.getRangeUpgradeEquation());
     }
 
@@ -180,13 +175,13 @@ class DefaultUpgradeSeederTest {
         UpgradeTier tier = capturedTierFor("BSkyBlock_example_range2_t1");
         assertNotNull(tier, "Tier for Border Expansion II must be saved");
 
-        assertTrue(tier.getPrices().stream().anyMatch(p -> p instanceof IslandLevelPriceDB),
+        assertTrue(tier.getPrices().stream().anyMatch(IslandLevelPriceDB.class::isInstance),
                 "Border Expansion II must have an IslandLevelPrice");
         IslandLevelPriceDB levelPrice = (IslandLevelPriceDB) tier.getPrices().stream()
-                .filter(p -> p instanceof IslandLevelPriceDB).findFirst().orElseThrow();
+                .filter(IslandLevelPriceDB.class::isInstance).findFirst().orElseThrow();
         assertEquals("100", levelPrice.getLevelNeededEquation());
 
-        assertTrue(tier.getPrices().stream().anyMatch(p -> p instanceof MoneyPriceDB),
+        assertTrue(tier.getPrices().stream().anyMatch(MoneyPriceDB.class::isInstance),
                 "Border Expansion II must also have a MoneyPrice");
     }
 
@@ -199,14 +194,14 @@ class DefaultUpgradeSeederTest {
         UpgradeTier tier = capturedTierFor("BSkyBlock_example_diamond_t1");
         assertNotNull(tier, "Tier for Diamond Border must be saved");
 
-        assertTrue(tier.getPrices().stream().anyMatch(p -> p instanceof ItemPriceDB),
+        assertTrue(tier.getPrices().stream().anyMatch(ItemPriceDB.class::isInstance),
                 "Diamond Border must have an ItemPrice");
         ItemPriceDB item = (ItemPriceDB) tier.getPrices().stream()
-                .filter(p -> p instanceof ItemPriceDB).findFirst().orElseThrow();
+                .filter(ItemPriceDB.class::isInstance).findFirst().orElseThrow();
         assertEquals("DIAMOND", item.getMaterial());
         assertEquals(10, item.getAmount());
 
-        assertTrue(tier.getRewards().stream().anyMatch(r -> r instanceof RangeRewardDB),
+        assertTrue(tier.getRewards().stream().anyMatch(RangeRewardDB.class::isInstance),
                 "Diamond Border must have a RangeReward");
     }
 
@@ -219,16 +214,16 @@ class DefaultUpgradeSeederTest {
         UpgradeTier tier = capturedTierFor("BSkyBlock_example_donor_t1");
         assertNotNull(tier, "Tier for Donor Perk must be saved");
 
-        assertTrue(tier.getPrices().stream().anyMatch(p -> p instanceof PermissionPriceDB),
+        assertTrue(tier.getPrices().stream().anyMatch(PermissionPriceDB.class::isInstance),
                 "Donor Perk must have a PermissionPrice");
         PermissionPriceDB perm = (PermissionPriceDB) tier.getPrices().stream()
-                .filter(p -> p instanceof PermissionPriceDB).findFirst().orElseThrow();
+                .filter(PermissionPriceDB.class::isInstance).findFirst().orElseThrow();
         assertEquals("upgrades.example.donor", perm.getPermission());
 
-        assertTrue(tier.getRewards().stream().anyMatch(r -> r instanceof CommandRewardDB),
+        assertTrue(tier.getRewards().stream().anyMatch(CommandRewardDB.class::isInstance),
                 "Donor Perk must have a CommandReward");
         CommandRewardDB cmd = (CommandRewardDB) tier.getRewards().stream()
-                .filter(r -> r instanceof CommandRewardDB).findFirst().orElseThrow();
+                .filter(CommandRewardDB.class::isInstance).findFirst().orElseThrow();
         assertFalse(cmd.getCommands().isEmpty(), "CommandReward must have at least one command");
         assertTrue(cmd.isConsole(), "Donor Perk command must be run as console");
     }
@@ -242,10 +237,10 @@ class DefaultUpgradeSeederTest {
         UpgradeTier tier = capturedTierFor("BSkyBlock_example_hopper_t1");
         assertNotNull(tier, "Tier for Hopper Limit must be saved");
 
-        assertTrue(tier.getRewards().stream().anyMatch(r -> r instanceof LimitsRewardDB),
+        assertTrue(tier.getRewards().stream().anyMatch(LimitsRewardDB.class::isInstance),
                 "Hopper Limit must have a LimitsReward");
         LimitsRewardDB limits = (LimitsRewardDB) tier.getRewards().stream()
-                .filter(r -> r instanceof LimitsRewardDB).findFirst().orElseThrow();
+                .filter(LimitsRewardDB.class::isInstance).findFirst().orElseThrow();
         assertEquals("BLOCK", limits.getLimitType());
         assertEquals("HOPPER", limits.getTarget());
         assertEquals("2", limits.getAmountEquation());
@@ -259,7 +254,7 @@ class DefaultUpgradeSeederTest {
         assertNotNull(tier, "Tier for Cow Limit must be saved");
 
         LimitsRewardDB limits = (LimitsRewardDB) tier.getRewards().stream()
-                .filter(r -> r instanceof LimitsRewardDB).findFirst().orElse(null);
+                .filter(LimitsRewardDB.class::isInstance).findFirst().orElse(null);
         assertNotNull(limits);
         assertEquals("ENTITY", limits.getLimitType());
         assertEquals("COW", limits.getTarget());
@@ -292,9 +287,9 @@ class DefaultUpgradeSeederTest {
         assertNotNull(tier);
 
         assertTrue(tier.getRewards().stream()
-                .anyMatch(r -> r instanceof CropGrowthRewardDB));
+                .anyMatch(CropGrowthRewardDB.class::isInstance));
         CropGrowthRewardDB crop = (CropGrowthRewardDB) tier.getRewards().stream()
-                .filter(r -> r instanceof CropGrowthRewardDB)
+                .filter(CropGrowthRewardDB.class::isInstance)
                 .findFirst().orElseThrow();
         assertEquals("0.5", crop.getGrowthBonusEquation());
     }

--- a/src/test/java/world/bentobox/upgrades/UpgradesAddonTest.java
+++ b/src/test/java/world/bentobox/upgrades/UpgradesAddonTest.java
@@ -1,6 +1,8 @@
 package world.bentobox.upgrades;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -67,7 +69,7 @@ import world.bentobox.upgrades.api.UpgradeAPI;
 /**
  * @author tastybento
  */
-public class UpgradesAddonTest {
+class UpgradesAddonTest {
 
     private static File jFile;
     @Mock
@@ -112,7 +114,7 @@ public class UpgradesAddonTest {
     private MockedStatic<IslandsManager> mockIslandsManager;
 
     @BeforeAll
-    public static void beforeClass() throws IOException {
+    static void beforeClass() throws IOException {
         // Make the addon jar
         jFile = new File("addon.jar");
         // Copy over config file from src folder
@@ -144,7 +146,7 @@ public class UpgradesAddonTest {
      */
     @SuppressWarnings("deprecation")
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         MockitoAnnotations.openMocks(this);
         MockBukkit.mock();
         mockBukkit = Mockito.mockStatic(Bukkit.class, Mockito.RETURNS_MOCKS);
@@ -187,7 +189,8 @@ public class UpgradesAddonTest {
         Server server = mock(Server.class);
         when(Bukkit.getServer()).thenReturn(server);
         when(Bukkit.getLogger()).thenReturn(Logger.getAnonymousLogger());
-        when(Bukkit.getPluginManager()).thenReturn(mock(PluginManager.class));
+        PluginManager pluginManagerMock = mock(PluginManager.class);
+        when(Bukkit.getPluginManager()).thenReturn(pluginManagerMock);
 
         // Addon
         addon = new UpgradesAddon();
@@ -247,7 +250,7 @@ public class UpgradesAddonTest {
      * @throws java.lang.Exception
      */
     @AfterEach
-    public void tearDown() throws Exception {
+    void tearDown() throws Exception {
         MockBukkit.unmock();
         mockBukkit.closeOnDemand();
         mockIslandsManager.closeOnDemand();
@@ -255,7 +258,7 @@ public class UpgradesAddonTest {
     }
 
     @AfterAll
-    public static void cleanUp() throws Exception {
+    static void cleanUp() throws Exception {
         new File("addon.jar").delete();
         new File("config.yml").delete();
         deleteAll(new File("addons"));
@@ -271,7 +274,7 @@ public class UpgradesAddonTest {
      * Test method for {@link world.bentobox.upgrades.UpgradesAddon#onEnable()}.
      */
     @Test
-    public void testOnEnableDisabled() {
+    void testOnEnableDisabled() {
         addon.onLoad();
         addon.setState(State.DISABLED);
         addon.onEnable();
@@ -282,7 +285,7 @@ public class UpgradesAddonTest {
      * Test method for {@link world.bentobox.upgrades.UpgradesAddon#onEnable()}.
      */
     @Test
-    public void testOnEnableNoAddons() {
+    void testOnEnableNoAddons() {
         addon.onLoad();
         addon.setState(State.ENABLED);
         addon.onEnable();
@@ -295,97 +298,101 @@ public class UpgradesAddonTest {
      * Test method for {@link world.bentobox.upgrades.UpgradesAddon#onDisable()}.
      */
     @Test
-    public void testOnDisable() {
-        addon.onDisable();
+    void testOnDisable() {
+        assertDoesNotThrow(() -> addon.onDisable());
     }
 
     /**
      * Test method for {@link world.bentobox.upgrades.UpgradesAddon#onLoad()}.
      */
     @Test
-    public void testOnLoad() {
-        addon.onLoad();
+    void testOnLoad() {
+        assertDoesNotThrow(() -> addon.onLoad());
     }
 
     /**
      * Test method for {@link world.bentobox.upgrades.UpgradesAddon#onReload()}.
      */
     @Test
-    public void testOnReload() {
-        addon.onReload();
+    void testOnReload() {
+        assertDoesNotThrow(() -> addon.onReload());
     }
 
     /**
      * Test method for {@link world.bentobox.upgrades.UpgradesAddon#getSettings()}.
      */
     @Test
-    public void testGetSettings() {
-        addon.getSettings();
+    void testGetSettings() {
+        addon.onLoad();
+        assertNotNull(addon.getSettings());
     }
 
     /**
      * Test method for {@link world.bentobox.upgrades.UpgradesAddon#getUpgradesManager()}.
      */
     @Test
-    public void testGetUpgradesManager() {
-        addon.getUpgradesManager();
+    void testGetUpgradesManager() {
+        addon.onLoad();
+        addon.setState(State.ENABLED);
+        addon.onEnable();
+        assertNotNull(addon.getUpgradesManager());
     }
 
     /**
      * Test method for {@link world.bentobox.upgrades.UpgradesAddon#getDatabase()}.
      */
     @Test
-    public void testGetDatabase() {
-        addon.getDatabase();
+    void testGetDatabase() {
+        assertNotNull(addon.getDatabase());
     }
 
     /**
      * Test method for {@link world.bentobox.upgrades.UpgradesAddon#getUpgradesLevels(java.lang.String)}.
      */
     @Test
-    public void testGetUpgradesLevels() {
+    void testGetUpgradesLevels() {
         addon.onLoad();
         addon.onEnable();
-        addon.getUpgradesLevels(targetIslandId);
+        assertNotNull(addon.getUpgradesLevels(targetIslandId));
     }
 
     /**
      * Test method for {@link world.bentobox.upgrades.UpgradesAddon#uncacheIsland(java.lang.String, boolean)}.
      */
     @Test
-    public void testUncacheIsland() {
-        addon.uncacheIsland(targetIslandId, false);
+    void testUncacheIsland() {
+        assertDoesNotThrow(() -> addon.uncacheIsland(targetIslandId, false));
     }
 
     /**
      * Test method for {@link world.bentobox.upgrades.UpgradesAddon#getLevelAddon()}.
      */
     @Test
-    public void testGetLevelAddon() {
-        addon.getLevelAddon();
+    void testGetLevelAddon() {
+        assertDoesNotThrow(() -> addon.getLevelAddon());
     }
 
     /**
      * Test method for {@link world.bentobox.upgrades.UpgradesAddon#getLimitsAddon()}.
      */
     @Test
-    public void testGetLimitsAddon() {
-        addon.getLimitsAddon();
+    void testGetLimitsAddon() {
+        assertDoesNotThrow(() -> addon.getLimitsAddon());
     }
 
     /**
      * Test method for {@link world.bentobox.upgrades.UpgradesAddon#getVaultHook()}.
      */
     @Test
-    public void testGetVaultHook() {
-        addon.getVaultHook();
+    void testGetVaultHook() {
+        assertDoesNotThrow(() -> addon.getVaultHook());
     }
 
     /**
      * Test method for {@link world.bentobox.upgrades.UpgradesAddon#isLevelProvided()}.
      */
     @Test
-    public void testIsLevelProvided() {
+    void testIsLevelProvided() {
         assertFalse(addon.isLevelProvided());
     }
 
@@ -393,7 +400,7 @@ public class UpgradesAddonTest {
      * Test method for {@link world.bentobox.upgrades.UpgradesAddon#isLimitsProvided()}.
      */
     @Test
-    public void testIsLimitsProvided() {
+    void testIsLimitsProvided() {
         assertFalse(addon.isLimitsProvided());
     }
 
@@ -401,7 +408,7 @@ public class UpgradesAddonTest {
      * Test method for {@link world.bentobox.upgrades.UpgradesAddon#isVaultProvided()}.
      */
     @Test
-    public void testIsVaultProvided() {
+    void testIsVaultProvided() {
         assertFalse(addon.isVaultProvided());
     }
 
@@ -409,17 +416,17 @@ public class UpgradesAddonTest {
      * Test method for {@link world.bentobox.upgrades.UpgradesAddon#getAvailableUpgrades()}.
      */
     @Test
-    public void testGetAvailableUpgrades() {
-        addon.getAvailableUpgrades();
+    void testGetAvailableUpgrades() {
+        assertNotNull(addon.getAvailableUpgrades());
     }
 
     /**
      * Test method for {@link world.bentobox.upgrades.UpgradesAddon#registerUpgrade(world.bentobox.upgrades.api.Upgrade)}.
      */
     @Test
-    public void testRegisterUpgrade() {
+    void testRegisterUpgrade() {
         UpgradeAPI upgrade = new TestUpgrade(addon, "name", "Name", Material.ACACIA_BOAT);
-        addon.registerUpgrade(upgrade);
+        assertDoesNotThrow(() -> addon.registerUpgrade(upgrade));
     }
 
     private static class TestUpgrade extends UpgradeAPI {

--- a/src/test/java/world/bentobox/upgrades/api/UpgradeTest.java
+++ b/src/test/java/world/bentobox/upgrades/api/UpgradeTest.java
@@ -32,7 +32,7 @@ import world.bentobox.upgrades.dataobjects.UpgradesData;
 /**
  * @author tastybento
  */
-public class UpgradeTest {
+class UpgradeTest {
 
     @Mock
     private UpgradesAddon addon;
@@ -53,7 +53,7 @@ public class UpgradeTest {
     private TestUpgrade testUpgrade;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         MockBukkit.mock();
 
         MockitoAnnotations.openMocks(this);
@@ -82,7 +82,7 @@ public class UpgradeTest {
     }
 
     @Test
-    public void testUpgradeInitialization() {
+    void testUpgradeInitialization() {
         assertNotNull(testUpgrade.getUpgradesAddon());
         assertEquals("test_upgrade", testUpgrade.getName());
         assertEquals("Test Upgrade", testUpgrade.getDisplayName());
@@ -90,7 +90,7 @@ public class UpgradeTest {
     }
 
     @Test
-    public void testCanUpgrade_WithSufficientResources() {
+    void testCanUpgrade_WithSufficientResources() {
         UpgradeAPI.UpgradeValues upgradeValues = testUpgrade.new UpgradeValues(5, 100, 1);
         testUpgrade.setUpgradeValues(user, upgradeValues);
 
@@ -103,7 +103,7 @@ public class UpgradeTest {
     }
 
     @Test
-    public void testCanUpgrade_WithInsufficientResources() {
+    void testCanUpgrade_WithInsufficientResources() {
         UpgradeAPI.UpgradeValues upgradeValues = testUpgrade.new UpgradeValues(10, 200, 1);
         testUpgrade.setUpgradeValues(user, upgradeValues);
 
@@ -116,7 +116,7 @@ public class UpgradeTest {
     }
 
     @Test
-    public void testDoUpgrade_SuccessfulTransaction() {
+    void testDoUpgrade_SuccessfulTransaction() {
         UpgradeAPI.UpgradeValues upgradeValues = testUpgrade.new UpgradeValues(5, 100, 1);
         testUpgrade.setUpgradeValues(user, upgradeValues);
 
@@ -129,7 +129,7 @@ public class UpgradeTest {
     }
 
     @Test
-    public void testDoUpgrade_FailedTransaction() {
+    void testDoUpgrade_FailedTransaction() {
         UpgradeAPI.UpgradeValues upgradeValues = testUpgrade.new UpgradeValues(5, 100, 1);
         testUpgrade.setUpgradeValues(user, upgradeValues);
 
@@ -141,7 +141,7 @@ public class UpgradeTest {
     }
 
     @Test
-    public void testGetAndSetDescription() {
+    void testGetAndSetDescription() {
         String description = "Upgrade description";
         testUpgrade.setOwnDescription(user, description);
 
@@ -149,7 +149,7 @@ public class UpgradeTest {
     }
 
     @Test
-    public void testGetAndSetUpgradeValues() {
+    void testGetAndSetUpgradeValues() {
         UpgradeAPI.UpgradeValues upgradeValues = testUpgrade.new UpgradeValues(5, 100, 1);
         testUpgrade.setUpgradeValues(user, upgradeValues);
 

--- a/src/test/java/world/bentobox/upgrades/command/PlayerUpgradeCommandTest.java
+++ b/src/test/java/world/bentobox/upgrades/command/PlayerUpgradeCommandTest.java
@@ -49,7 +49,7 @@ import world.bentobox.upgrades.config.Settings;
 /**
  * @author tastybento
  */
-public class PlayerUpgradeCommandTest {
+class PlayerUpgradeCommandTest {
 
     @Mock
     private UpgradesAddon addon;
@@ -84,7 +84,7 @@ public class PlayerUpgradeCommandTest {
      * @throws java.lang.Exception
      */
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         MockitoAnnotations.openMocks(this);
         MockBukkit.mock();
         // Config
@@ -106,7 +106,7 @@ public class PlayerUpgradeCommandTest {
         when(rm.getRank(anyInt())).thenReturn(RanksManager.MEMBER_RANK_REF);
         when(plugin.getRanksManager()).thenReturn(rm);
         ranksManagerStatic = Mockito.mockStatic(RanksManager.class);
-        ranksManagerStatic.when(() -> RanksManager.getInstance()).thenReturn(rm);
+        ranksManagerStatic.when(RanksManager::getInstance).thenReturn(rm);
 
         // Command manager
         CommandsManager cm = mock(CommandsManager.class);
@@ -166,7 +166,7 @@ public class PlayerUpgradeCommandTest {
     /**
      */
     @AfterEach
-    public void tearDown() {
+    void tearDown() {
         MockBukkit.unmock();
         User.clearUsers();
         bukkitMock.closeOnDemand();
@@ -178,7 +178,7 @@ public class PlayerUpgradeCommandTest {
      * Test method for {@link world.bentobox.upgrades.command.PlayerUpgradeCommand#PlayerUpgradeCommand(world.bentobox.upgrades.UpgradesAddon, world.bentobox.bentobox.api.commands.CompositeCommand)}.
      */
     @Test
-    public void testPlayerUpgradeCommand() {
+    void testPlayerUpgradeCommand() {
         assertEquals("upgrade", puc.getLabel());
     }
 
@@ -186,7 +186,7 @@ public class PlayerUpgradeCommandTest {
      * Test method for {@link world.bentobox.upgrades.command.PlayerUpgradeCommand#setup()}.
      */
     @Test
-    public void testSetup() {
+    void testSetup() {
         assertEquals("", puc.getPermission());
         assertEquals("upgrades.commands.main.description", puc.getDescription());
         assertTrue(puc.isOnlyPlayer());
@@ -196,7 +196,7 @@ public class PlayerUpgradeCommandTest {
      * Test method for {@link world.bentobox.upgrades.command.PlayerUpgradeCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteNoIsland() {
+    void testCanExecuteNoIsland() {
         assertFalse(puc.canExecute(user, "", List.of()));
         verify(user).sendMessage("general.errors.no-island");
     }
@@ -205,7 +205,7 @@ public class PlayerUpgradeCommandTest {
      * Test method for {@link world.bentobox.upgrades.command.PlayerUpgradeCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteNotOnIsland() {
+    void testCanExecuteNotOnIsland() {
         when(im.getIsland(world, user)).thenReturn(island);
         assertFalse(puc.canExecute(user, "", List.of()));
         verify(user).sendMessage("upgrades.error.notonisland");
@@ -215,7 +215,7 @@ public class PlayerUpgradeCommandTest {
      * Test method for {@link world.bentobox.upgrades.command.PlayerUpgradeCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteInsufficientRank() {
+    void testCanExecuteInsufficientRank() {
         when(im.getIsland(world, user)).thenReturn(island);
         when(island.onIsland(location)).thenReturn(true);
         assertFalse(puc.canExecute(user, "", List.of()));
@@ -226,7 +226,7 @@ public class PlayerUpgradeCommandTest {
      * Test method for {@link world.bentobox.upgrades.command.PlayerUpgradeCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testCanExecuteSuccess() {
+    void testCanExecuteSuccess() {
         when(im.getIsland(world, user)).thenReturn(island);
         when(island.onIsland(location)).thenReturn(true);
         when(island.isAllowed(eq(user), any())).thenReturn(true);
@@ -237,7 +237,7 @@ public class PlayerUpgradeCommandTest {
      * Test method for {@link world.bentobox.upgrades.command.PlayerUpgradeCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringNoIsland() {
+    void testExecuteUserStringListOfStringNoIsland() {
         assertFalse(puc.execute(user, "", List.of()));
         verify(user).sendMessage("general.errors.no-island");
 
@@ -247,7 +247,7 @@ public class PlayerUpgradeCommandTest {
      * Test method for {@link world.bentobox.upgrades.command.PlayerUpgradeCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteUserStringListOfStringShowHelp() {
+    void testExecuteUserStringListOfStringShowHelp() {
         assertFalse(puc.execute(user, "", List.of("random")));
         verify(user).sendMessage("commands.help.header", "[label]", "BSkyBlock");
 
@@ -257,7 +257,7 @@ public class PlayerUpgradeCommandTest {
      * Test method for {@link world.bentobox.upgrades.command.PlayerUpgradeCommand#execute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteNotOnIsland() {
+    void testExecuteNotOnIsland() {
         when(im.getIsland(world, user)).thenReturn(island);
         assertFalse(puc.execute(user, "", List.of()));
         verify(user).sendMessage("upgrades.error.notonisland");
@@ -267,7 +267,7 @@ public class PlayerUpgradeCommandTest {
      * Test method for {@link world.bentobox.upgrades.command.PlayerUpgradeCommand#canExecute(world.bentobox.bentobox.api.user.User, java.lang.String, java.util.List)}.
      */
     @Test
-    public void testExecuteSuccess() {
+    void testExecuteSuccess() {
         when(im.getIsland(world, user)).thenReturn(island);
         when(island.onIsland(location)).thenReturn(true);
         when(island.isAllowed(eq(user), any())).thenReturn(true);

--- a/src/test/java/world/bentobox/upgrades/config/SettingsEvaluateTest.java
+++ b/src/test/java/world/bentobox/upgrades/config/SettingsEvaluateTest.java
@@ -590,4 +590,252 @@ class SettingsEvaluateTest {
         });
         assertNotNull(ex.getMessage());
     }
+
+    // ============= Additional Edge Cases =============
+
+    @Test
+    void testFunctionCaseSensitivity() {
+        // Function names are case-sensitive. "Sqrt" is not recognized as sqrt.
+        // It will be treated as a variable instead.
+        Expression expr = Settings.parse("Sqrt", Map.of("Sqrt", 99.0));
+        assertEquals(99.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testUnknownFunctionNameAsVariable() {
+        // "power" is not in the function list, so it's treated as a variable
+        Expression expr = Settings.parse("power", Map.of("power", 42.0));
+        assertEquals(42.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testLargeNumbers() {
+        Expression expr = Settings.parse("1000000 + 2000000", Map.of());
+        assertEquals(3000000.0, expr.eval(), 0.1);
+    }
+
+    @Test
+    void testVerySmallNumbers() {
+        Expression expr = Settings.parse("0.000001 + 0.000002", Map.of());
+        assertEquals(0.000003, expr.eval(), 0.0000001);
+    }
+
+    @Test
+    void testLargeExponent() {
+        Expression expr = Settings.parse("2 ^ 10", Map.of());
+        assertEquals(1024.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testZeroRaisedToPositivePower() {
+        Expression expr = Settings.parse("0 ^ 5", Map.of());
+        assertEquals(0.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testOneRaisedToAnyPower() {
+        Expression expr = Settings.parse("1 ^ 999", Map.of());
+        assertEquals(1.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testVariableInComplexExpression() {
+        // Demonstrates that variables work anywhere in expressions
+        Expression expr = Settings.parse("[a] * [b] + [c] / [d]",
+                Map.of("[a]", 2.0, "[b]", 3.0, "[c]", 10.0, "[d]", 2.0));
+        assertEquals(11.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testMultipleVariableReferences() {
+        // Same variable referenced multiple times
+        Expression expr = Settings.parse("[x] + [x] * [x]",
+                Map.of("[x]", 3.0));
+        assertEquals(12.0, expr.eval(), 0.0001); // 3 + 3*3 = 3 + 9 = 12
+    }
+
+    @Test
+    void testSqrtOfZero() {
+        Expression expr = Settings.parse("sqrt(0)", Map.of());
+        assertEquals(0.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testSqrtOfOne() {
+        Expression expr = Settings.parse("sqrt(1)", Map.of());
+        assertEquals(1.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testSqrtOfDecimal() {
+        Expression expr = Settings.parse("sqrt(0.25)", Map.of());
+        assertEquals(0.5, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testMultiplicationByZero() {
+        Expression expr = Settings.parse("99999 * 0", Map.of());
+        assertEquals(0.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testDivisionOfZeroByNumber() {
+        Expression expr = Settings.parse("0 / 5", Map.of());
+        assertEquals(0.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testParenthesesChangingPrecedenceMultiple() {
+        Expression expr = Settings.parse("2 * 3 + 4 * 5", Map.of());
+        Expression expr2 = Settings.parse("(2 * 3 + 4) * 5", Map.of());
+        assertEquals(26.0, expr.eval(), 0.0001);
+        assertEquals(50.0, expr2.eval(), 0.0001);
+    }
+
+    @Test
+    void testFunctionWithDecimalResult() {
+        Expression expr = Settings.parse("sqrt(2)", Map.of());
+        double result = expr.eval();
+        assertEquals(Math.sqrt(2), result, 0.0001);
+    }
+
+    @Test
+    void testCosine90Degrees() {
+        // cos(90 degrees) should be approximately 0
+        Expression expr = Settings.parse("cos(90)", Map.of());
+        assertEquals(0.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testTangent0Degrees() {
+        // tan(0 degrees) should be 0
+        Expression expr = Settings.parse("tan(0)", Map.of());
+        assertEquals(0.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testFunctionWithVariableArgument() {
+        Expression expr = Settings.parse("sin([angle])", Map.of("[angle]", 0.0));
+        assertEquals(0.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testComplexFormulaWithAllFeatures() {
+        // Combines multiple features: parentheses, functions, variables, operators
+        Expression expr = Settings.parse("sqrt([base] * [base] + [height] * [height])",
+                Map.of("[base]", 3.0, "[height]", 4.0));
+        // sqrt(3*3 + 4*4) = sqrt(9 + 16) = sqrt(25) = 5
+        assertEquals(5.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testDivisionPrecedenceOverAddition() {
+        Expression expr = Settings.parse("10 + 20 / 5", Map.of());
+        assertEquals(14.0, expr.eval(), 0.0001); // 10 + 4, not (10 + 20) / 5
+    }
+
+    @Test
+    void testSubtractionLeftAssociative() {
+        Expression expr = Settings.parse("20 - 5 - 3", Map.of());
+        assertEquals(12.0, expr.eval(), 0.0001); // (20 - 5) - 3 = 15 - 3 = 12
+    }
+
+    @Test
+    void testDivisionLeftAssociative() {
+        Expression expr = Settings.parse("16 / 4 / 2", Map.of());
+        assertEquals(2.0, expr.eval(), 0.0001); // (16 / 4) / 2 = 4 / 2 = 2
+    }
+
+    @Test
+    void testExponentiationAllowsDecimals() {
+        Expression expr = Settings.parse("9 ^ 0.5", Map.of());
+        assertEquals(3.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testUnknownVariableInExpressionThrowsNPE() {
+        Expression expr = Settings.parse("5 + [unknown]", Map.of());
+        // The expression parses fine, but eval() throws NPE when trying to unbox null
+        assertThrows(NullPointerException.class, expr::eval);
+    }
+
+    @Test
+    void testWhitespaceBeforeFunctionArgument() {
+        Expression expr = Settings.parse("sqrt( 4 )", Map.of());
+        assertEquals(2.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testDoubleDotInNumber() {
+        // "1.2.3" would parse all dots as part of the number token,
+        // then Double.parseDouble("1.2.3") throws a NumberFormatException
+        assertThrows(NumberFormatException.class, () -> {
+            Settings.parse("1.2.3", Map.of()).eval();
+        });
+    }
+
+    @Test
+    void testBracketNotInVariableName() {
+        // A bracket outside a variable context should cause an error
+        FormulaParseException ex = assertThrows(FormulaParseException.class, () -> {
+            Settings.parse("] 2", Map.of());
+        });
+        assertTrue(ex.getMessage().contains("Unexpected"));
+    }
+
+    @Test
+    void testMultipleParenthesesLevels() {
+        Expression expr = Settings.parse("((((2 + 3))))", Map.of());
+        assertEquals(5.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testFunctionWithExpressionInsideParentheses() {
+        Expression expr = Settings.parse("sqrt((2 + 2))", Map.of());
+        assertEquals(2.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testProjectConfigExampleRange() {
+        // Real example from config: cost formula
+        Expression expr = Settings.parse("100 * [level]", Map.of("[level]", 5.0));
+        assertEquals(500.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testProjectConfigExampleWithIslandLevel() {
+        // Real example using both level and islandLevel
+        Expression expr = Settings.parse("[level] * 10 + [islandLevel] * 5",
+                Map.of("[level]", 2.0, "[islandLevel]", 10.0));
+        assertEquals(70.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testProjectConfigExampleWithNumberPlayer() {
+        // Real example using numberPlayer
+        Expression expr = Settings.parse("500 + [numberPlayer] * 50",
+                Map.of("[numberPlayer]", 3.0));
+        assertEquals(650.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testNegativeNumberViaSubtraction() {
+        // Demonstrates workaround for lack of unary minus
+        Expression expr = Settings.parse("0 - 10", Map.of());
+        assertEquals(-10.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testExponentiationRightAssociativityProof() {
+        // 2^3^2 should equal 512 (2^9), not 64 ((2^3)^2)
+        Expression expr = Settings.parse("2 ^ 3 ^ 2", Map.of());
+        assertEquals(512.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testNegativeNumberViaVariable() {
+        // Variables can hold negative values
+        Expression expr = Settings.parse("[value] * 2", Map.of("[value]", -5.0));
+        assertEquals(-10.0, expr.eval(), 0.0001);
+    }
 }

--- a/src/test/java/world/bentobox/upgrades/config/SettingsEvaluateTest.java
+++ b/src/test/java/world/bentobox/upgrades/config/SettingsEvaluateTest.java
@@ -1,0 +1,593 @@
+package world.bentobox.upgrades.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import world.bentobox.upgrades.config.FormulaParseException;
+import world.bentobox.upgrades.config.Settings;
+import world.bentobox.upgrades.config.Settings.Expression;
+
+/**
+ * Characterization tests for the expression parser in Settings.
+ * These tests pin down the CURRENT behavior of Settings.parse() and Settings.evaluate()
+ * to detect any changes during refactoring.
+ *
+ * @author tastybento
+ */
+class SettingsEvaluateTest {
+
+    // ============= Basic Arithmetic and Operator Precedence =============
+
+    @Test
+    void testSimpleAddition() {
+        Expression expr = Settings.parse("2 + 3", Map.of());
+        assertEquals(5.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testSimpleSubtraction() {
+        Expression expr = Settings.parse("5 - 3", Map.of());
+        assertEquals(2.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testSimpleMultiplication() {
+        Expression expr = Settings.parse("3 * 4", Map.of());
+        assertEquals(12.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testSimpleDivision() {
+        Expression expr = Settings.parse("12 / 3", Map.of());
+        assertEquals(4.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testMultiplicationBeforeAddition() {
+        // Multiplication should have higher precedence than addition
+        Expression expr = Settings.parse("2 + 3 * 4", Map.of());
+        assertEquals(14.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testDivisionBeforeSubtraction() {
+        // Division should have higher precedence than subtraction
+        Expression expr = Settings.parse("10 - 6 / 2", Map.of());
+        assertEquals(7.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testMultipleOperations() {
+        Expression expr = Settings.parse("1 + 2 * 3 + 4", Map.of());
+        assertEquals(11.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testLeftToRightForSamePrecedence() {
+        // Addition and subtraction are left-associative
+        Expression expr = Settings.parse("10 - 3 - 2", Map.of());
+        assertEquals(5.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testLeftToRightDivisionAndMultiplication() {
+        // Multiplication and division are left-associative
+        Expression expr = Settings.parse("12 / 3 * 2", Map.of());
+        assertEquals(8.0, expr.eval(), 0.0001);
+    }
+
+    // ============= Parentheses and Nesting =============
+
+    @Test
+    void testSimpleParentheses() {
+        Expression expr = Settings.parse("(2 + 3) * 4", Map.of());
+        assertEquals(20.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testNestedParentheses() {
+        Expression expr = Settings.parse("((2 + 3) * 4) + 1", Map.of());
+        assertEquals(21.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testParenthesesWithSubtraction() {
+        Expression expr = Settings.parse("(10 - 3) * 2", Map.of());
+        assertEquals(14.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testParenthesesWithDivision() {
+        Expression expr = Settings.parse("20 / (2 + 3)", Map.of());
+        assertEquals(4.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testDeeplyNestedParentheses() {
+        Expression expr = Settings.parse("(((2 + 3)))", Map.of());
+        assertEquals(5.0, expr.eval(), 0.0001);
+    }
+
+    // ============= Exponentiation =============
+
+    @Test
+    void testSimpleExponentiation() {
+        Expression expr = Settings.parse("2 ^ 3", Map.of());
+        assertEquals(8.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testSquaring() {
+        Expression expr = Settings.parse("10 ^ 2", Map.of());
+        assertEquals(100.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testExponentiationRightAssociativity() {
+        // 2 ^ 3 ^ 2 should be 2^(3^2) = 2^9 = 512, not (2^3)^2 = 8^2 = 64
+        Expression expr = Settings.parse("2 ^ 3 ^ 2", Map.of());
+        assertEquals(512.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testExponentiationWithNegativeVariable() {
+        // Exponentiation with negative value via variable
+        Expression expr = Settings.parse("[x] ^ 3", Map.of("[x]", -2.0));
+        assertEquals(-8.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testExponentiationWithDecimal() {
+        Expression expr = Settings.parse("4 ^ 0.5", Map.of());
+        assertEquals(2.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testExponentiationInExpression() {
+        Expression expr = Settings.parse("2 ^ 3 + 1", Map.of());
+        assertEquals(9.0, expr.eval(), 0.0001);
+    }
+
+    // ============= Functions =============
+
+    @Test
+    void testSqrtFunction() {
+        Expression expr = Settings.parse("sqrt(4)", Map.of());
+        assertEquals(2.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testSqrtOfNine() {
+        Expression expr = Settings.parse("sqrt(9)", Map.of());
+        assertEquals(3.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testSinZero() {
+        // sin(0 degrees) = 0
+        Expression expr = Settings.parse("sin(0)", Map.of());
+        assertEquals(0.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testCosZero() {
+        // cos(0 degrees) = 1
+        Expression expr = Settings.parse("cos(0)", Map.of());
+        assertEquals(1.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testTan45() {
+        // tan(45 degrees) = 1
+        Expression expr = Settings.parse("tan(45)", Map.of());
+        assertEquals(1.0, expr.eval(), 0.001); // Slightly wider tolerance for trig
+    }
+
+    @Test
+    void testSin90() {
+        // sin(90 degrees) = 1
+        Expression expr = Settings.parse("sin(90)", Map.of());
+        assertEquals(1.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testFunctionWithExpression() {
+        Expression expr = Settings.parse("sqrt(4 + 5)", Map.of());
+        assertEquals(3.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testSqrtWithMultiplication() {
+        Expression expr = Settings.parse("sqrt(4) * 2", Map.of());
+        assertEquals(4.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testNestedFunctions() {
+        Expression expr = Settings.parse("sqrt(sqrt(16))", Map.of());
+        assertEquals(2.0, expr.eval(), 0.0001);
+    }
+
+    // ============= Variable Substitution =============
+
+    @Test
+    void testSimpleVariableSubstitution() {
+        Expression expr = Settings.parse("[level]", Map.of("[level]", 5.0));
+        assertEquals(5.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testVariableInExpression() {
+        Expression expr = Settings.parse("100 * [level]", Map.of("[level]", 5.0));
+        assertEquals(500.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testMultipleVariables() {
+        Expression expr = Settings.parse("[level] + [islandLevel]",
+                Map.of("[level]", 3.0, "[islandLevel]", 7.0));
+        assertEquals(10.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testVariableWithMultiplication() {
+        Expression expr = Settings.parse("2 * [level] * 3", Map.of("[level]", 5.0));
+        assertEquals(30.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testVariableWithExponentiation() {
+        Expression expr = Settings.parse("[level] ^ 2", Map.of("[level]", 3.0));
+        assertEquals(9.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testProjectStyleVariableNumberPlayer() {
+        Expression expr = Settings.parse("100 + [numberPlayer]", Map.of("[numberPlayer]", 5.0));
+        assertEquals(105.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testVariableComplexExpression() {
+        Expression expr = Settings.parse("[level] * 10 + [islandLevel] * 5",
+                Map.of("[level]", 2.0, "[islandLevel]", 3.0));
+        assertEquals(35.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testVariableWithFunction() {
+        Expression expr = Settings.parse("sqrt([level])", Map.of("[level]", 16.0));
+        assertEquals(4.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testVariableInParentheses() {
+        Expression expr = Settings.parse("([level] + 3) * 2", Map.of("[level]", 5.0));
+        assertEquals(16.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testVariableLongerName() {
+        Expression expr = Settings.parse("[levelMax]", Map.of("[levelMax]", 10.0));
+        assertEquals(10.0, expr.eval(), 0.0001);
+    }
+
+    // ============= Whitespace Handling =============
+
+    @Test
+    void testWhitespaceAroundAddition() {
+        Expression expr = Settings.parse("  2   +   3  ", Map.of());
+        assertEquals(5.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testWhitespaceAroundMultiplication() {
+        Expression expr = Settings.parse("3 * 4", Map.of());
+        assertEquals(12.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testWhitespaceInsideParentheses() {
+        Expression expr = Settings.parse("( 2 + 3 ) * 4", Map.of());
+        assertEquals(20.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testWhitespaceBeforeFunction() {
+        Expression expr = Settings.parse("  sqrt(4)", Map.of());
+        assertEquals(2.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testLeadingWhitespace() {
+        Expression expr = Settings.parse("   5 * 2", Map.of());
+        assertEquals(10.0, expr.eval(), 0.0001);
+    }
+
+    // ============= Decimal Numbers =============
+
+    @Test
+    void testSimpleDecimal() {
+        Expression expr = Settings.parse("1.5 + 2.5", Map.of());
+        assertEquals(4.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testDecimalMultiplication() {
+        Expression expr = Settings.parse("0.5 * 4", Map.of());
+        assertEquals(2.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testDecimalStartingWithDot() {
+        Expression expr = Settings.parse(".5 + .5", Map.of());
+        assertEquals(1.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testDecimalDivision() {
+        Expression expr = Settings.parse("5.0 / 2.0", Map.of());
+        assertEquals(2.5, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testMultipleDecimalPlaces() {
+        Expression expr = Settings.parse("1.234 + 2.766", Map.of());
+        assertEquals(4.0, expr.eval(), 0.0001);
+    }
+
+    // ============= Notes on Unary Operators =============
+    // The unary minus implementation has a bug: it returns a lambda without parsing the operand,
+    // leaving unparsed content which causes parse() to throw "Unexpected: X" error.
+    // Therefore, bare unary minus does NOT work in this parser for any operand type.
+    // Workaround: use subtraction instead (e.g., "0 - 5" instead of "-5")
+
+    @Test
+    void testSubtractionFromZeroForNegative() {
+        Expression expr = Settings.parse("0 - 5", Map.of());
+        assertEquals(-5.0, expr.eval(), 0.0001);
+    }
+
+    // ============= Division by Zero and Special Cases =============
+
+    @Test
+    void testDivisionByZero() {
+        Expression expr = Settings.parse("5 / 0", Map.of());
+        double result = expr.eval();
+        assertTrue(Double.isInfinite(result) && result > 0, "Expected positive infinity");
+    }
+
+    @Test
+    void testNegativeDivisionByZero() {
+        // Use variable for negative value since bare -5 doesn't parse
+        Expression expr = Settings.parse("[x] / 0", Map.of("[x]", -5.0));
+        double result = expr.eval();
+        assertTrue(Double.isInfinite(result) && result < 0, "Expected negative infinity");
+    }
+
+    @Test
+    void testZeroToZeroPower() {
+        Expression expr = Settings.parse("0 ^ 0", Map.of());
+        // Java Math.pow(0.0, 0.0) returns 1.0
+        assertEquals(1.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testZeroMultipliedByAnything() {
+        Expression expr = Settings.parse("0 * 999999", Map.of());
+        assertEquals(0.0, expr.eval(), 0.0001);
+    }
+
+    // ============= Malformed Input =============
+
+    @Test
+    void testEmptyString() {
+        FormulaParseException ex = assertThrows(FormulaParseException.class, () -> {
+            Settings.parse("", Map.of());
+        });
+        // Parser will throw when trying to parse with ch == -1
+        assertNotNull(ex.getMessage());
+    }
+
+    @Test
+    void testUnbalancedLeftParen() {
+        // Parser silently accepts missing closing paren - it doesn't throw
+        Expression expr = Settings.parse("(2 + 3", Map.of());
+        assertEquals(5.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testUnbalancedRightParen() {
+        FormulaParseException ex = assertThrows(FormulaParseException.class, () -> {
+            Settings.parse("2 + 3)", Map.of());
+        });
+        assertTrue(ex.getMessage().contains("Unexpected"));
+    }
+
+    @Test
+    void testUnknownCharacter() {
+        FormulaParseException ex = assertThrows(FormulaParseException.class, () -> {
+            Settings.parse("2 + 3 & 4", Map.of());
+        });
+        assertTrue(ex.getMessage().contains("Unexpected"));
+    }
+
+    @Test
+    void testUnknownCharacterAtStart() {
+        FormulaParseException ex = assertThrows(FormulaParseException.class, () -> {
+            Settings.parse("@ 2 + 3", Map.of());
+        });
+        assertTrue(ex.getMessage().contains("Unexpected"));
+    }
+
+    @Test
+    void testMissingOperand() {
+        FormulaParseException ex = assertThrows(FormulaParseException.class, () -> {
+            Settings.parse("2 +", Map.of());
+        });
+        assertNotNull(ex.getMessage());
+    }
+
+    // ============= Unknown Variables and Functions =============
+
+    @Test
+    void testUnknownVariableThrowsNPE() {
+        Expression expr = Settings.parse("[unknown]", Map.of());
+        // The parser treats it as a variable and calls variables.get("[unknown]")
+        // which returns null. Auto-unboxing null to double throws NPE.
+        assertThrows(NullPointerException.class, expr::eval);
+    }
+
+    @Test
+    void testUnknownFunctionTreatedAsVariable() {
+        // "unknown" is not in the funct list, so it's treated as a variable
+        Expression expr = Settings.parse("unknown", Map.of("unknown", 42.0));
+        assertEquals(42.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testVariableSubstringPrefix() {
+        // [level] and [levelMax] - ensure correct matching
+        Map<String, Double> vars = Map.of("[level]", 5.0, "[levelMax]", 20.0);
+        Expression expr1 = Settings.parse("[level]", vars);
+        Expression expr2 = Settings.parse("[levelMax]", vars);
+        assertEquals(5.0, expr1.eval(), 0.0001);
+        assertEquals(20.0, expr2.eval(), 0.0001);
+    }
+
+    // ============= Complex Real-World Scenarios =============
+
+    @Test
+    void testFormulasFromProjectConfig() {
+        // Example: 100*[level] (range upgrade cost)
+        Expression expr = Settings.parse("100*[level]", Map.of("[level]", 3.0));
+        assertEquals(300.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testMultiplierWithPlayerCount() {
+        // Example: 500 + [numberPlayer] * 50
+        Expression expr = Settings.parse("500 + [numberPlayer] * 50",
+                Map.of("[numberPlayer]", 4.0));
+        assertEquals(700.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testComplexFormula() {
+        // Example with multiple operations and variables
+        Expression expr = Settings.parse("([level] ^ 2) * 100 + [islandLevel] * 10",
+                Map.of("[level]", 2.0, "[islandLevel]", 5.0));
+        assertEquals(450.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testFormulaWithSqrt() {
+        Expression expr = Settings.parse("100 * sqrt([level])",
+                Map.of("[level]", 4.0));
+        assertEquals(200.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testUsingEvaluateMethod() {
+        double result = Settings.evaluate("2 + 3 * 4", Map.of());
+        assertEquals(14.0, result, 0.0001);
+    }
+
+    @Test
+    void testUsingEvaluateMethodWithVariables() {
+        double result = Settings.evaluate("100 * [level]", Map.of("[level]", 5.0));
+        assertEquals(500.0, result, 0.0001);
+    }
+
+    // ============= Edge Cases with Variable Names =============
+
+    @Test
+    void testVariableWithBracketsAtStart() {
+        Expression expr = Settings.parse("[a]", Map.of("[a]", 1.0));
+        assertEquals(1.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testVariableWithBracketsAtEnd() {
+        Expression expr = Settings.parse("[z]", Map.of("[z]", 99.0));
+        assertEquals(99.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testVariableWithMultipleBracketsAndLetters() {
+        // Variable names can only contain letters and brackets, not digits
+        // [myLevel] will be parsed as a variable, "123]" will cause parse error
+        FormulaParseException ex = assertThrows(FormulaParseException.class, () -> {
+            Settings.parse("[myLevel123]", Map.of("[myLevel123]", 42.0));
+        });
+        assertTrue(ex.getMessage().contains("Unexpected"));
+    }
+
+    // ============= Additional Operator Precedence Tests =============
+
+    @Test
+    void testExponentiationHigherThanMultiplication() {
+        // 2 * 3 ^ 2 should be 2 * 9 = 18, not (2*3) ^ 2 = 36
+        Expression expr = Settings.parse("2 * 3 ^ 2", Map.of());
+        assertEquals(18.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testExponentiationHigherThanDivision() {
+        // 8 / 2 ^ 2 should be 8 / 4 = 2, not (8/2) ^ 2 = 16
+        Expression expr = Settings.parse("8 / 2 ^ 2", Map.of());
+        assertEquals(2.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testLongChainOfOperations() {
+        Expression expr = Settings.parse("1 + 2 - 3 + 4 - 5", Map.of());
+        assertEquals(-1.0, expr.eval(), 0.0001);
+    }
+
+    // ============= More Complex Parentheses Tests =============
+
+    @Test
+    void testParenthesesChangePrecedence() {
+        Expression expr1 = Settings.parse("2 + 3 * 4", Map.of());
+        Expression expr2 = Settings.parse("(2 + 3) * 4", Map.of());
+        assertEquals(14.0, expr1.eval(), 0.0001);
+        assertEquals(20.0, expr2.eval(), 0.0001);
+    }
+
+    @Test
+    void testParenthesesReverseSubtraction() {
+        // Cannot use unary minus, use subtraction instead for negative results
+        Expression expr = Settings.parse("0 - (5 + 3) * 2", Map.of());
+        assertEquals(-16.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testFunctionPrecedenceWithOtherOperators() {
+        // sqrt(4) * 3 should be 2 * 3 = 6
+        Expression expr = Settings.parse("sqrt(4) * 3", Map.of());
+        assertEquals(6.0, expr.eval(), 0.0001);
+    }
+
+    @Test
+    void testFunctionWithComplexArgument() {
+        Expression expr = Settings.parse("sqrt(2 * 8)", Map.of());
+        assertEquals(4.0, expr.eval(), 0.0001);
+    }
+
+    // ============= Trailing/Leading Operators =============
+
+    @Test
+    void testExtraWhitespaceOnly() {
+        FormulaParseException ex = assertThrows(FormulaParseException.class, () -> {
+            Settings.parse("   ", Map.of());
+        });
+        assertNotNull(ex.getMessage());
+    }
+}

--- a/src/test/java/world/bentobox/upgrades/config/SettingsTest.java
+++ b/src/test/java/world/bentobox/upgrades/config/SettingsTest.java
@@ -26,7 +26,7 @@ import world.bentobox.upgrades.config.Settings.Expression;
 /**
  * @author tastybento
  */
-public class SettingsTest {
+class SettingsTest {
 
     @Mock
     private UpgradesAddon addon;
@@ -37,7 +37,7 @@ public class SettingsTest {
      * @throws java.lang.Exception
      */
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         MockitoAnnotations.openMocks(this);
         MockBukkit.mock();
         // Config
@@ -52,7 +52,7 @@ public class SettingsTest {
     }
 
     @AfterEach
-    public void tearDown() {
+    void tearDown() {
         MockBukkit.unmock();
     }
 
@@ -60,7 +60,7 @@ public class SettingsTest {
      * Test method for {@link world.bentobox.upgrades.config.Settings#Settings(world.bentobox.upgrades.UpgradesAddon)}.
      */
     @Test
-    public void testSettings() {
+    void testSettings() {
         assertNotNull(settings);
     }
 
@@ -68,7 +68,7 @@ public class SettingsTest {
      * Test method for {@link world.bentobox.upgrades.config.Settings#getDisabledGameModes()}.
      */
     @Test
-    public void testGetDisabledGameModes() {
+    void testGetDisabledGameModes() {
         assertTrue(settings.getDisabledGameModes().isEmpty());
     }
 
@@ -76,7 +76,7 @@ public class SettingsTest {
      * Test method for {@link world.bentobox.upgrades.config.Settings#getHasRangeUpgrade()}.
      */
     @Test
-    public void testGetHasRangeUpgrade() {
+    void testGetHasRangeUpgrade() {
         assertTrue(settings.getHasRangeUpgrade());
     }
 
@@ -84,7 +84,7 @@ public class SettingsTest {
      * Test method for {@link world.bentobox.upgrades.config.Settings#getMaxRangeUpgrade(java.lang.String)}.
      */
     @Test
-    public void testGetMaxRangeUpgrade() {
+    void testGetMaxRangeUpgrade() {
         assertEquals(10, settings.getMaxRangeUpgrade(""));
     }
 
@@ -92,7 +92,7 @@ public class SettingsTest {
      * Test method for {@link world.bentobox.upgrades.config.Settings#getDefaultRangeUpgradeTierMap()}.
      */
     @Test
-    public void testGetDefaultRangeUpgradeTierMap() {
+    void testGetDefaultRangeUpgradeTierMap() {
         assertFalse(settings.getDefaultRangeUpgradeTierMap().isEmpty());
     }
 
@@ -100,7 +100,7 @@ public class SettingsTest {
      * Test method for {@link world.bentobox.upgrades.config.Settings#getAddonRangeUpgradeTierMap(java.lang.String)}.
      */
     @Test
-    public void testGetAddonRangeUpgradeTierMap() {
+    void testGetAddonRangeUpgradeTierMap() {
         assertTrue(settings.getAddonRangeUpgradeTierMap("").isEmpty());
     }
 
@@ -108,7 +108,7 @@ public class SettingsTest {
      * Test method for {@link world.bentobox.upgrades.config.Settings#getMaxBlockLimitsUpgrade(org.bukkit.Material, java.lang.String)}.
      */
     @Test
-    public void testGetMaxBlockLimitsUpgrade() {
+    void testGetMaxBlockLimitsUpgrade() {
         assertEquals(0, settings.getMaxBlockLimitsUpgrade(Material.STONE, ""));
     }
 
@@ -116,7 +116,7 @@ public class SettingsTest {
      * Test method for {@link world.bentobox.upgrades.config.Settings#getDefaultBlockLimitsUpgradeTierMap()}.
      */
     @Test
-    public void testGetDefaultBlockLimitsUpgradeTierMap() {
+    void testGetDefaultBlockLimitsUpgradeTierMap() {
         assertFalse(settings.getDefaultBlockLimitsUpgradeTierMap().isEmpty());
 
     }
@@ -125,7 +125,7 @@ public class SettingsTest {
      * Test method for {@link world.bentobox.upgrades.config.Settings#getAddonBlockLimitsUpgradeTierMap(java.lang.String)}.
      */
     @Test
-    public void testGetAddonBlockLimitsUpgradeTierMap() {
+    void testGetAddonBlockLimitsUpgradeTierMap() {
         assertTrue(settings.getAddonBlockLimitsUpgradeTierMap("").isEmpty());
     }
 
@@ -133,7 +133,7 @@ public class SettingsTest {
      * Test method for {@link world.bentobox.upgrades.config.Settings#getMaterialsLimitsUpgrade()}.
      */
     @Test
-    public void testGetMaterialsLimitsUpgrade() {
+    void testGetMaterialsLimitsUpgrade() {
         assertFalse(settings.getMaterialsLimitsUpgrade().isEmpty());
     }
 
@@ -141,7 +141,7 @@ public class SettingsTest {
      * Test method for {@link world.bentobox.upgrades.config.Settings#getEntityIcon(org.bukkit.entity.EntityType)}.
      */
     @Test
-    public void testGetEntityIcon() {
+    void testGetEntityIcon() {
         assertNull(settings.getEntityIcon(EntityType.CAT));
     }
 
@@ -149,7 +149,7 @@ public class SettingsTest {
      * Test method for {@link world.bentobox.upgrades.config.Settings#getEntityGroupIcon(java.lang.String)}.
      */
     @Test
-    public void testGetEntityGroupIcon() {
+    void testGetEntityGroupIcon() {
         assertNull(settings.getEntityGroupIcon(""));
     }
 
@@ -157,7 +157,7 @@ public class SettingsTest {
      * Test method for {@link world.bentobox.upgrades.config.Settings#getMaxEntityLimitsUpgrade(org.bukkit.entity.EntityType, java.lang.String)}.
      */
     @Test
-    public void testGetMaxEntityLimitsUpgrade() {
+    void testGetMaxEntityLimitsUpgrade() {
         assertEquals(0, settings.getMaxEntityLimitsUpgrade(EntityType.HOPPER_MINECART, ""));
     }
 
@@ -165,7 +165,7 @@ public class SettingsTest {
      * Test method for {@link world.bentobox.upgrades.config.Settings#getMaxEntityGroupLimitsUpgrade(java.lang.String, java.lang.String)}.
      */
     @Test
-    public void testGetMaxEntityGroupLimitsUpgrade() {
+    void testGetMaxEntityGroupLimitsUpgrade() {
         assertEquals(0, settings.getMaxEntityGroupLimitsUpgrade("", ""));
     }
 
@@ -173,7 +173,7 @@ public class SettingsTest {
      * Test method for {@link world.bentobox.upgrades.config.Settings#getDefaultEntityLimitsUpgradeTierMap()}.
      */
     @Test
-    public void testGetDefaultEntityLimitsUpgradeTierMap() {
+    void testGetDefaultEntityLimitsUpgradeTierMap() {
         assertFalse(settings.getDefaultEntityLimitsUpgradeTierMap().isEmpty());
     }
 
@@ -181,7 +181,7 @@ public class SettingsTest {
      * Test method for {@link world.bentobox.upgrades.config.Settings#getDefaultEntityGroupLimitsUpgradeTierMap()}.
      */
     @Test
-    public void testGetDefaultEntityGroupLimitsUpgradeTierMap() {
+    void testGetDefaultEntityGroupLimitsUpgradeTierMap() {
         assertFalse(settings.getDefaultEntityGroupLimitsUpgradeTierMap().isEmpty());
     }
 
@@ -189,7 +189,7 @@ public class SettingsTest {
      * Test method for {@link world.bentobox.upgrades.config.Settings#getAddonEntityLimitsUpgradeTierMap(java.lang.String)}.
      */
     @Test
-    public void testGetAddonEntityLimitsUpgradeTierMap() {
+    void testGetAddonEntityLimitsUpgradeTierMap() {
         assertTrue(settings.getAddonEntityLimitsUpgradeTierMap("").isEmpty());
     }
 
@@ -197,7 +197,7 @@ public class SettingsTest {
      * Test method for {@link world.bentobox.upgrades.config.Settings#getAddonEntityGroupLimitsUpgradeTierMap(java.lang.String)}.
      */
     @Test
-    public void testGetAddonEntityGroupLimitsUpgradeTierMap() {
+    void testGetAddonEntityGroupLimitsUpgradeTierMap() {
         assertTrue(settings.getAddonEntityGroupLimitsUpgradeTierMap("").isEmpty());
     }
 
@@ -205,7 +205,7 @@ public class SettingsTest {
      * Test method for {@link world.bentobox.upgrades.config.Settings#getEntityLimitsUpgrade()}.
      */
     @Test
-    public void testGetEntityLimitsUpgrade() {
+    void testGetEntityLimitsUpgrade() {
         assertFalse(settings.getEntityLimitsUpgrade().isEmpty());
     }
 
@@ -213,7 +213,7 @@ public class SettingsTest {
      * Test method for {@link world.bentobox.upgrades.config.Settings#getEntityGroupLimitsUpgrade()}.
      */
     @Test
-    public void testGetEntityGroupLimitsUpgrade() {
+    void testGetEntityGroupLimitsUpgrade() {
         assertFalse(settings.getEntityGroupLimitsUpgrade().isEmpty());
     }
 
@@ -221,7 +221,7 @@ public class SettingsTest {
      * Test method for {@link world.bentobox.upgrades.config.Settings#getMaxCommandUpgrade(java.lang.String, java.lang.String)}.
      */
     @Test
-    public void testGetMaxCommandUpgrade() {
+    void testGetMaxCommandUpgrade() {
         assertEquals(0, settings.getMaxCommandUpgrade("", ""));
     }
 
@@ -229,7 +229,7 @@ public class SettingsTest {
      * Test method for {@link world.bentobox.upgrades.config.Settings#getDefaultCommandUpgradeTierMap()}.
      */
     @Test
-    public void testGetDefaultCommandUpgradeTierMap() {
+    void testGetDefaultCommandUpgradeTierMap() {
         assertFalse(settings.getDefaultCommandUpgradeTierMap().isEmpty());
     }
 
@@ -237,7 +237,7 @@ public class SettingsTest {
      * Test method for {@link world.bentobox.upgrades.config.Settings#getAddonCommandUpgradeTierMap(java.lang.String)}.
      */
     @Test
-    public void testGetAddonCommandUpgradeTierMap() {
+    void testGetAddonCommandUpgradeTierMap() {
         assertTrue(settings.getAddonCommandUpgradeTierMap("").isEmpty());
     }
 
@@ -245,7 +245,7 @@ public class SettingsTest {
      * Test method for {@link world.bentobox.upgrades.config.Settings#getCommandUpgrade()}.
      */
     @Test
-    public void testGetCommandUpgrade() {
+    void testGetCommandUpgrade() {
         assertFalse(settings.getCommandUpgrade().isEmpty());
     }
 
@@ -253,7 +253,7 @@ public class SettingsTest {
      * Test method for {@link world.bentobox.upgrades.config.Settings#getCommandIcon(java.lang.String)}.
      */
     @Test
-    public void testGetCommandIcon() {
+    void testGetCommandIcon() {
         assertNull(settings.getCommandIcon(""));
     }
 
@@ -261,7 +261,7 @@ public class SettingsTest {
      * Test method for {@link world.bentobox.upgrades.config.Settings#getCommandName(java.lang.String)}.
      */
     @Test
-    public void testGetCommandName() {
+    void testGetCommandName() {
         assertNull(settings.getCommandName(""));
     }
 
@@ -269,7 +269,7 @@ public class SettingsTest {
      * Test method for {@link world.bentobox.upgrades.config.Settings#parse(java.lang.String, java.util.Map)}.
      */
     @Test
-    public void testParse() {
+    void testParse() {
         Expression expression = Settings.parse("40*200", Map.of());
         assertEquals(8000D, expression.eval(), 0.1D);
     }

--- a/src/test/java/world/bentobox/upgrades/dataobjects/UpgradesDataTest.java
+++ b/src/test/java/world/bentobox/upgrades/dataobjects/UpgradesDataTest.java
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.Test;
  * old default of 1, it would see currentLevel=1 and 0<=1<=0 is false —
  * causing every DB upgrade to appear permanently maxed on a fresh island.
  */
-public class UpgradesDataTest {
+class UpgradesDataTest {
 
     private static final String KEY = "BSkyBlock_diamond";
     private static final String ISLAND_ID = "island-uuid-1234";

--- a/src/test/java/world/bentobox/upgrades/dataobjects/prices/PricesTest.java
+++ b/src/test/java/world/bentobox/upgrades/dataobjects/prices/PricesTest.java
@@ -6,7 +6,6 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
-import java.util.Collections;
 import java.util.UUID;
 
 import org.bukkit.Material;

--- a/src/test/java/world/bentobox/upgrades/dataobjects/rewards/RewardsTest.java
+++ b/src/test/java/world/bentobox/upgrades/dataobjects/rewards/RewardsTest.java
@@ -5,7 +5,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 

--- a/src/test/java/world/bentobox/upgrades/ui/PanelTest.java
+++ b/src/test/java/world/bentobox/upgrades/ui/PanelTest.java
@@ -40,7 +40,7 @@ import world.bentobox.upgrades.WhiteBox;
 /**
  * @author tastybento
  */
-public class PanelTest {
+class PanelTest {
 
     @Mock
     private UpgradesAddon addon;
@@ -68,7 +68,7 @@ public class PanelTest {
     /**
      */
     @BeforeEach
-    public void setUp() throws IOException {
+    void setUp() throws IOException {
         MockitoAnnotations.openMocks(this);
         MockBukkit.mock();
 
@@ -110,7 +110,7 @@ public class PanelTest {
     /**
      */
     @AfterEach
-    public void tearDown() throws IOException {
+    void tearDown() throws IOException {
         User.clearUsers();
         WhiteBox.setInternalState(BentoBox.class, "instance", null);
         mockBukkit.closeOnDemand();
@@ -127,7 +127,7 @@ public class PanelTest {
      * Test method for {@link world.bentobox.upgrades.ui.Panel#Panel(world.bentobox.upgrades.UpgradesAddon, world.bentobox.bentobox.database.objects.Island)}.
      */
     @Test
-    public void testPanel() {
+    void testPanel() {
         assertNotNull(panel);
     }
 
@@ -135,7 +135,7 @@ public class PanelTest {
      * Test method for {@link world.bentobox.upgrades.ui.Panel#showPanel(world.bentobox.bentobox.api.user.User)}.
      */
     @Test
-    public void testShowPanel() {
+    void testShowPanel() {
         panel.showPanel(user);
         verify(p).openInventory(any(Inventory.class));
     }

--- a/src/test/java/world/bentobox/upgrades/ui/admin/EditUpgradePanelSaveTest.java
+++ b/src/test/java/world/bentobox/upgrades/ui/admin/EditUpgradePanelSaveTest.java
@@ -7,7 +7,6 @@ import static org.mockito.Mockito.*;
 import java.util.Collections;
 import java.util.List;
 
-import org.bukkit.Material;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/world/bentobox/upgrades/upgrades/CommandUpgradeTest.java
+++ b/src/test/java/world/bentobox/upgrades/upgrades/CommandUpgradeTest.java
@@ -2,8 +2,7 @@ package world.bentobox.upgrades.upgrades;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.HashSet;
@@ -31,7 +30,7 @@ import world.bentobox.upgrades.dataobjects.UpgradesData;
 /**
  * Test for CommandUpgrade
  */
-public class CommandUpgradeTest {
+class CommandUpgradeTest {
 
     @Mock
     private UpgradesAddon addon;
@@ -55,7 +54,7 @@ public class CommandUpgradeTest {
     private String islandId;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         MockBukkit.mock();
 
         MockitoAnnotations.openMocks(this);
@@ -78,7 +77,7 @@ public class CommandUpgradeTest {
     }
 
     @AfterEach
-    public void tearDown() {
+    void tearDown() {
         MockBukkit.unmock();
     }
 
@@ -86,7 +85,7 @@ public class CommandUpgradeTest {
      * Test that isShowed returns true when permission level is 0 (no permission required)
      */
     @Test
-    public void testIsShowed_NoPermissionRequired() {
+    void testIsShowed_NoPermissionRequired() {
         // Set up the mock to return permission level 0
         when(upgradesData.getUpgradeLevel("command-coal-upgrade")).thenReturn(0);
         when(um.getCommandPermissionLevel("coal-upgrade", 0, world)).thenReturn(0);
@@ -103,7 +102,7 @@ public class CommandUpgradeTest {
      * while updateUpgradeValue() and doUpgrade() were correctly using this.getName().
      */
     @Test
-    public void testIsShowed_UsesCorrectUpgradeKey() {
+    void testIsShowed_UsesCorrectUpgradeKey() {
         // The upgrade data is stored with the key "command-coal-upgrade" (this.getName())
         // not "coal-upgrade" (this.cmdId)
         when(upgradesData.getUpgradeLevel("command-coal-upgrade")).thenReturn(1);
@@ -123,7 +122,7 @@ public class CommandUpgradeTest {
      * Test that isShowed returns false when player doesn't have required permission
      */
     @Test
-    public void testIsShowed_NoPermission() {
+    void testIsShowed_NoPermission() {
         when(upgradesData.getUpgradeLevel("command-coal-upgrade")).thenReturn(0);
         when(um.getCommandPermissionLevel("coal-upgrade", 0, world)).thenReturn(1);
 
@@ -139,7 +138,7 @@ public class CommandUpgradeTest {
      * Test that isShowed returns true when player has sufficient permission level
      */
     @Test
-    public void testIsShowed_WithSufficientPermission() {
+    void testIsShowed_WithSufficientPermission() {
         when(upgradesData.getUpgradeLevel("command-coal-upgrade")).thenReturn(0);
         when(um.getCommandPermissionLevel("coal-upgrade", 0, world)).thenReturn(1);
 
@@ -157,7 +156,7 @@ public class CommandUpgradeTest {
      * Test that isShowed returns false when player has insufficient permission level
      */
     @Test
-    public void testIsShowed_WithInsufficientPermission() {
+    void testIsShowed_WithInsufficientPermission() {
         when(upgradesData.getUpgradeLevel("command-coal-upgrade")).thenReturn(0);
         when(um.getCommandPermissionLevel("coal-upgrade", 0, world)).thenReturn(2);
 
@@ -175,7 +174,7 @@ public class CommandUpgradeTest {
      * Test that isShowed returns false for wildcard permissions
      */
     @Test
-    public void testIsShowed_WildcardNotAllowed() {
+    void testIsShowed_WildcardNotAllowed() {
         when(upgradesData.getUpgradeLevel("command-coal-upgrade")).thenReturn(0);
         when(um.getCommandPermissionLevel("coal-upgrade", 0, world)).thenReturn(1);
 
@@ -193,7 +192,7 @@ public class CommandUpgradeTest {
      * Helper method to create a mock PermissionAttachmentInfo
      */
     private PermissionAttachmentInfo createMockPermission(String permission, boolean value) {
-        PermissionAttachmentInfo info = org.mockito.Mockito.mock(PermissionAttachmentInfo.class);
+        PermissionAttachmentInfo info = mock(PermissionAttachmentInfo.class);
         when(info.getPermission()).thenReturn(permission);
         when(info.getValue()).thenReturn(value);
         return info;

--- a/src/test/java/world/bentobox/upgrades/upgrades/DatabaseUpgradeTest.java
+++ b/src/test/java/world/bentobox/upgrades/upgrades/DatabaseUpgradeTest.java
@@ -48,7 +48,7 @@ import world.bentobox.upgrades.dataobjects.rewards.RewardDB;
  *  - canUpgrade() delegates to each Price.canPay().
  *  - doUpgrade() calls Price.pay(), Reward.apply(), and increments the level.
  */
-public class DatabaseUpgradeTest {
+class DatabaseUpgradeTest {
 
     @Mock private UpgradesAddon addon;
     @Mock private BentoBox plugin;
@@ -331,7 +331,7 @@ public class DatabaseUpgradeTest {
         PriceDB priceDB = mock(PriceDB.class);
         Price price = mock(Price.class);
         when(upgradesManager.searchPrice(any())).thenReturn(price);
-        when(price.getPublicDescription(eq(user), eq(priceDB))).thenReturn("Costs 100 money");
+        when(price.getPublicDescription(user, priceDB)).thenReturn("Costs 100 money");
         tier.setPrices(List.of(priceDB));
 
         databaseUpgrade.updateUpgradeValue(user, island);


### PR DESCRIPTION
## New in this release

* 🔺 Fixes a `NoSuchMethodError` that broke **every limits-based upgrade** when the Limits addon was up to date. Clicking a block, entity or entity-group upgrade in `/[gamemode] upgrades` threw `IslandBlockCount.getBlockLimitsOffset()` and the purchase failed. Limits 1.28.2 replaced its single offset maps with per-environment (overworld / nether / end) maps, and Upgrades was still calling the removed methods. Upgrades now uses the per-environment API and raises the offset in every environment, so upgrades stay island-wide exactly as before.
* Fixes nine latent bugs found by static analysis, including six potential `NullPointerException`s in the price and reward formula paths and a null command sender that could be passed to `dispatchCommand`.
* Internal quality pass: shared helpers replace duplicated formula and limits-upgrade logic, and the test suite grew from 171 to 287 tests.

## Compatibility

✔️ BentoBox API 3.14.0
✔️ Minecraft 1.21.5 - 26.1.x
✔️ Java 21

> 🔺 **Limits addon note:** If you use the Limits addon, update it to **1.28.2 or newer** — this release is built against Limits 1.29.1 and requires the per-environment limits API. Your existing offsets are preserved: Limits migrates older single-map offsets into the overworld on load, and any upgrade purchased from now on applies to all three environments.

## Upgrading
1. Take backups of your server, for safety
2. Download this jar and put it in your addons folder - delete the old one
3. Update the Limits addon to 1.28.2 or newer if you use it
4. Restart the server
5. You should be good to go!

## Legend

- 🔺 special attention needed.

## What's Changed
* 🔺 fix: use environment-aware Limits offset API (NoSuchMethodError on upgrade) by @tastybento in https://github.com/BentoBoxWorld/Upgrades/pull/89
* refactor: extract LimitsUpgrade base class to remove duplication by @tastybento in https://github.com/BentoBoxWorld/Upgrades/pull/89
* fix: resolve SonarCloud bugs and code smells across the addon by @tastybento
* refactor(config): extract Settings constants, add formula parser tests by @tastybento
* refactor(config): reduce cognitive complexity in Settings by @tastybento

**Full Changelog**: https://github.com/BentoBoxWorld/Upgrades/compare/1.0.3...1.0.4

---

> **Note:** further 1.0.4 work landed after this PR was merged — see the follow-up PR for the `config.yml` cleanup and dead-code removal. The published 1.0.4 release notes should combine both.

## Test plan
- `mvn test` — 287 tests, 0 failures
- `mvn clean package` compiles against Limits 1.29.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GxCjgLNWwo2uTm6LrQ1eGA
