### PR TITLE
Release 1.0.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <revision>${build.version}-SNAPSHOT</revision>
 
         <!-- This allows to change between versions. -->
-        <build.version>1.0.4</build.version>
+        <build.version>1.0.5</build.version>
         <!-- Revision variable removes warning about dynamic version -->
         <revision>${build.version}-SNAPSHOT</revision>
         <!-- Do not change unless you want different name for local builds. -->

--- a/src/main/java/world/bentobox/upgrades/api/UpgradeAPI.java
+++ b/src/main/java/world/bentobox/upgrades/api/UpgradeAPI.java
@@ -158,6 +158,18 @@ public abstract class UpgradeAPI {
     }
 
     /**
+     * The highest level this upgrade can reach on the given island, used by the
+     * panel to show "current / max" in the item lore. Return -1 (the default) if
+     * the maximum is unknown and the lore line should be omitted.
+     *
+     * @param island island being viewed
+     * @return maximum purchasable level, or -1 if unknown
+     */
+    public int getMaxLevel(Island island) {
+        return -1;
+    }
+
+    /**
      * @return The actual description for the user
      */
     public String getOwnDescription(User user) {

--- a/src/main/java/world/bentobox/upgrades/ui/Panel.java
+++ b/src/main/java/world/bentobox/upgrades/ui/Panel.java
@@ -76,6 +76,13 @@ public class Panel {
         String ownDescription = upgrade.getOwnDescription(user);
         List<String> fullDescription = new ArrayList<>();
 
+        int maxLevel = upgrade.getMaxLevel(island);
+        if (maxLevel > 0) {
+            fullDescription.add(user.getTranslation("upgrades.ui.upgradepanel.currentlevel",
+                    "[current]", Integer.toString(upgrade.getUpgradeLevel(island)),
+                    "[max]", Integer.toString(maxLevel)));
+        }
+
         if (ownDescription != null) {
             fullDescription.add(ownDescription);
             if (upgrade.getUpgradeValues(user) != null) {

--- a/src/main/java/world/bentobox/upgrades/upgrades/DatabaseUpgrade.java
+++ b/src/main/java/world/bentobox/upgrades/upgrades/DatabaseUpgrade.java
@@ -131,6 +131,18 @@ public class DatabaseUpgrade extends UpgradeAPI {
     }
 
     /**
+     * A tier covering levels startLevel..endLevel allows a purchase at each of those
+     * levels, so the highest reachable level is the largest endLevel + 1.
+     */
+    @Override
+    public int getMaxLevel(Island island) {
+        List<UpgradeTier> tiers = this.getUpgradesAddon().getUpgradeDataManager()
+                .getUpgradeTierByUpgradeData(upgradeData);
+        return tiers.isEmpty() ? -1
+                : tiers.stream().mapToInt(UpgradeTier::getEndLevel).max().getAsInt() + 1;
+    }
+
+    /**
      * Find the tier that covers the current level (i.e. the next purchase available).
      * Level 0 = not yet purchased; a tier with startLevel=0, endLevel=0 means one purchase.
      */

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -44,6 +44,7 @@ upgrades:
         getupgradedataorder: "&c Order need to be a number greater than -1"
   ui:
     upgradepanel:
+      currentlevel: "&7 Level: &a[current]&7 / &2[max]"
       islandneed: "Island Min Level: [islandlevel]"
       limitsupgrade: "[block] limits upgrade of [level]"
       limitsupgradedone: "&a Your island [block] limits was upgraded by [level]"

--- a/src/main/resources/locales/fr.yml
+++ b/src/main/resources/locales/fr.yml
@@ -4,6 +4,7 @@ upgrades:
       description: Ouvre l'interface d'achats d'améliorations
   ui:
     upgradepanel:
+      currentlevel: "&7 Niveau : &a[current]&7 / &2[max]"
       title: Magasin d'améliorations de l'ile
       rangeupgrade: Amélioration de [rangelevel] blocs
       norangeupgrade: "&7 Zone agrandie"

--- a/src/main/resources/locales/ja.yml
+++ b/src/main/resources/locales/ja.yml
@@ -4,6 +4,7 @@ upgrades:
       description: アップグレードショップのインターフェースを開く
   ui:
     upgradepanel:
+      currentlevel: "&7 レベル: &a[current]&7 / &2[max]"
       title: アイランドアップグレードショップ
       rangeupgrade: "[rangelevel]の範囲アップグレード"
       norangeupgrade: "&7範囲アップグレード"

--- a/src/main/resources/locales/pl.yml
+++ b/src/main/resources/locales/pl.yml
@@ -15,6 +15,7 @@ upgrades:
       jeden blok"
   ui:
     upgradepanel:
+      currentlevel: "&7 Poziom: &a[current]&7 / &2[max]"
       islandneed: 'Minimalny poziom wyspy: [islandlevel]'
       limitsupgrade: Limit dla [block] to [level]
       limitsupgradedone: "&a Limit [block] na Twojej wyspy zostały zwiększone na [level]"

--- a/src/main/resources/locales/zh-CN.yml
+++ b/src/main/resources/locales/zh-CN.yml
@@ -9,7 +9,8 @@ upgrades:
     rangeovermax: "&c 尝试将岛屿边界扩大到最大值以上? 请将此问题告诉管理员"
     placeblock: "&c 在购买此升级之前, 您至少需要放置/破坏一个方块"
   ui: 
-    upgradepanel: 
+    upgradepanel:
+      currentlevel: "&7 等级: &a[current]&7 / &2[max]"
       islandneed: "岛屿最低等级: [islandlevel]"
       limitsupgrade: "[block] limits upgrade of [level]"
       limitsupgradedone: "&a 您岛屿的 [block] 限制已升级到 [level]"

--- a/src/test/java/world/bentobox/upgrades/upgrades/DatabaseUpgradeTest.java
+++ b/src/test/java/world/bentobox/upgrades/upgrades/DatabaseUpgradeTest.java
@@ -360,6 +360,41 @@ class DatabaseUpgradeTest {
                 "ownDescription must be null when maxed so PanelClick correctly blocks the click");
     }
 
+    // ─── getMaxLevel() ────────────────────────────────────────────────────
+
+    @Test
+    void getMaxLevel_singlePurchaseTier_isOne() {
+        // Tier 0-0: one purchase, so the highest reachable level is 1.
+        assertEquals(1, databaseUpgrade.getMaxLevel(island));
+    }
+
+    @Test
+    void getMaxLevel_multiLevelTier_isEndLevelPlusOne() {
+        tier.setEndLevel(2);
+        assertEquals(3, databaseUpgrade.getMaxLevel(island));
+    }
+
+    @Test
+    void getMaxLevel_multipleTiers_usesHighestEndLevel() {
+        UpgradeTier tier2 = new UpgradeTier();
+        tier2.setUniqueId("BSkyBlock_diamond_t2");
+        tier2.setUpgrade("BSkyBlock_diamond");
+        tier2.setStartLevel(1);
+        tier2.setEndLevel(4);
+        when(upgradesDataManager.getUpgradeTierByUpgradeData(upgradeData))
+                .thenReturn(List.of(tier, tier2));
+
+        assertEquals(5, databaseUpgrade.getMaxLevel(island));
+    }
+
+    @Test
+    void getMaxLevel_noTiers_isUnknown() {
+        when(upgradesDataManager.getUpgradeTierByUpgradeData(upgradeData))
+                .thenReturn(Collections.emptyList());
+        assertEquals(-1, databaseUpgrade.getMaxLevel(island),
+                "-1 means unknown — the panel omits the level line");
+    }
+
     // ─── Description substitution ─────────────────────────────────────────
 
     @Test


### PR DESCRIPTION
Release 1.0.5

* Upgrade items in the player shop now show a "Level: current / max" line in their lore, including when maxed out.
* 🔡 New locale key `upgrades.ui.upgradepanel.currentlevel` (translated in all five bundled locales).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ALbGYAJ1BgnX6rcNhAGoa